### PR TITLE
add ValidateSession use within VerifyAccount service, update docs + spelling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,28 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [1.7.1] - 2022-06-03
+
+### Addition
+- Add `verifyJWTExpiration`, a utility function to quickly test the `exp` field value of a JWT, in this case an `accessToken`. This allows the SDK to fail faster if the provided JWT is expired and not worth the XQ API call to test against
+### Modification
+- Modify `VerifyAccount` to utilize `ValidateSession` after adding the user + profile to the in-memory cache
+- Modify documentation use of `maybePayLoad` -> `maybePayload` (minor naming bug)
+- Ensure all services, regardless of `maybePayload` value, has the `validateInput` method invocation which ensures the `requiredFields` matches what fields are provided to the service. Meaning, even if the service isn't expecting a required value, we check for it. This ensures parity for each service.
+
 ## [1.7.0] - 2022-06-01
 
 ### Addition
 - Add `ValidateSession` service which consumes the `/session` endpoint. This is used to determine the validity of the XQ Dashboard session
-### Modified
+### Modification
+
+- Error handling updates: Modified `catch` block of `trycatch` utilized in each service. Added `handleException` function used to return the `ServerResponse` or create one.
+
+## [1.7.0] - 2022-06-01
+
+### Addition
+- Add `ValidateSession` service which consumes the `/session` endpoint. This is used to determine the validity of the XQ Dashboard session
+### Modification
 
 - Error handling updates: Modified `catch` block of `trycatch` utilized in each service. Added `handleException` function used to return the `ServerResponse` or create one.
 
@@ -20,16 +37,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add CRUD operations for businesses, including `AddBusiness`, `GetCurrentBusiness`, and `UpdateBusiness`.
 
 - Add CRUD operations for applications, including `AddApplication`, `RemoveApplication`, and `UpdateApplication`.
-### Modified
+### Modification
 
 - Update the `README.md` documentation file to reflect recent changes to the sdk.
 
 ## [1.5.3] - 2022-04-18
-### Modified
+### Modification
 
-- Update `Authorize` params to include `text` and `target`. `text` is an interpolated text field when a mobile number is specified. Use $pin to interpolate the pin or $link to interpolate the maybePayLoad.target. `target` is A link that can be interpolated in the maybePayload.text. Used for inviting users by text
+- Update `Authorize` params to include `text` and `target`. `text` is an interpolated text field when a mobile number is specified. Use $pin to interpolate the pin or $link to interpolate the maybePayload.target. `target` is A link that can be interpolated in the maybePayload.text. Used for inviting users by text
 ## [1.5.1] - 2022-03-28
-### Modified
+### Modification
 
 - Update `RevokeKeyAccess` expected params of `locatorKey` --> `locatorKeys`, a `string` --> `string[]`
 - Update `call` method of XQSDK to include check from DELETE http method when factoring in `maybePayload` presence
@@ -116,7 +133,7 @@ Utilizing `memory-cache` in lieu of `localStorage` required a few syntactic upda
 
 ## [1.0.27] - 2021-11-09
 
-### Modified
+### Modification
 - return type of `FileEncrypt.supplyAsync` from `void` --> `Promise<ServerResponse>`
 - return type of `locateFn`, the second parameter of `OTPv2Encryption.decryptFile`, a callback used to fetch the locator key of a given source file. From `string` --> `Promise<string>`
 - return type of `OTPv2Encryption.decryptFile` from `void` --> `Promise<unknown>`
@@ -125,7 +142,7 @@ Utilizing `memory-cache` in lieu of `localStorage` required a few syntactic upda
 
 ## [1.0.26] - 2021-11-09
 
-### Modified
+### Modification
 
 - `FileDecrypt` - update the type of the algorithm parameter of the `FileDecrypt` constructor to the `EncryptionAlgorithm` super class, rather than an omitted/stripped down version of the type. Also update return type from `void` --> `Promise<ServerResponse>` which is the correct return type.
 
@@ -139,7 +156,7 @@ Return value type - the return value was set to a type called void, which all it
 
 - `publish` script to `package.json` -- runs `yarn build` then `npm publish --access public` to ensure we build out our latest updates before publishing to NPM
 
-### Modified
+### Modification
 
 - naming of the `OPTV2` variable back to standardized `OTPv2`
 
@@ -151,7 +168,7 @@ Return value type - the return value was set to a type called void, which all it
 
 ## [1.0.22] - 2021-10-27
 
-### Modified
+### Modification
 
 - `AuthorizeAlias` -- `putActiveProfile` added after successful `AuthorizeAlias` call. Without this present, a user will be considered unauthorized and receive `401` errors regardless of payload validity
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xqmsg/jssdk-core",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A Javascript Implementation of XQ Message SDK, V.2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -67,6 +67,7 @@
     "webpack-cli": "^4.2.0"
   },
   "dependencies": {
+    "@xqmsg/jssdk-core": "file:.yalc/@xqmsg/jssdk-core",
     "buffer": "^6.0.3",
     "crypto-js": "3.1.9-1",
     "jwt-decode": "^3.1.2",

--- a/src/com/xqmsg/sdk/v2/quantum/FetchQuantumEntropy.ts
+++ b/src/com/xqmsg/sdk/v2/quantum/FetchQuantumEntropy.ts
@@ -24,7 +24,7 @@ export default class FetchQuantumEntropy extends XQModule {
   static _256: "256" = "256";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @param {String} ks -  The number of entropy bits to fetch
    * @returns {Promise<ServerResponse<{payload:{data:string}}>>}
    */
@@ -35,7 +35,7 @@ export default class FetchQuantumEntropy extends XQModule {
   constructor(sdk: XQSDK) {
     super(sdk);
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
         const additionalHeaderProperties = {
           [XQSDK.CONTENT_TYPE]: XQSDK.TEXT_PLAIN_UTF_8,
@@ -47,7 +47,7 @@ export default class FetchQuantumEntropy extends XQModule {
             null,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             false
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/Authorize.ts
+++ b/src/com/xqmsg/sdk/v2/services/Authorize.ts
@@ -57,16 +57,16 @@ export default class Authorize extends XQModule {
   static TARGET: "target" = "target";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {String} maybePayLoad.user - Email of the user to be validated.
-   * @param {String} [maybePayLoad.firstName]  - First name of the user.
-   * @param {String} [maybePayLoad.lastName] - Last name of the user.
-   * @param {Boolean} [maybePayLoad.newsLetter=false] - Should the user receive a newsletter.
-   * @param {NotificationEnum} [maybePayLoad.notifications=0] Enum Value to specify Notification Settings
-   * @param {String} maybePayLoad.accessToken - an already generated access token, if valid allows use to bypass authorization.
-   * @param {String} maybePayLoad.text - An interpolated text field when a mobile number is specified. Use $pin to interpolate the pin or $link to interpolate the maybePayLoad.target
-   * @param {String} maybePayLoad.target - A link that can be interpolated in the maybePayload.text. Used for inviting users by text
-   * @param {String} maybePayLoad.codetype - Codetype. Use 'sms' for inviting users by text.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {String} maybePayload.user - Email of the user to be validated.
+   * @param {String} [maybePayload.firstName]  - First name of the user.
+   * @param {String} [maybePayload.lastName] - Last name of the user.
+   * @param {Boolean} [maybePayload.newsLetter=false] - Should the user receive a newsletter.
+   * @param {NotificationEnum} [maybePayload.notifications=0] Enum Value to specify Notification Settings
+   * @param {String} maybePayload.accessToken - an already generated access token, if valid allows use to bypass authorization.
+   * @param {String} maybePayload.text - An interpolated text field when a mobile number is specified. Use $pin to interpolate the pin or $link to interpolate the maybePayload.target
+   * @param {String} maybePayload.target - A link that can be interpolated in the maybePayload.text. Used for inviting users by text
+   * @param {String} maybePayload.codetype - Codetype. Use 'sms' for inviting users by text.
    *
    * @returns {Promise<ServerResponse<{payload:string}>>}
    */
@@ -88,12 +88,12 @@ export default class Authorize extends XQModule {
     this.serviceName = "authorize";
     this.requiredFields = [Authorize.USER];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
         const self = this;
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
-        const user = maybePayLoad[Authorize.USER];
-        const existingAccessToken = maybePayLoad[Authorize.ACCESS_TOKEN];
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+        const user = maybePayload[Authorize.USER];
+        const existingAccessToken = maybePayload[Authorize.ACCESS_TOKEN];
 
         if (existingAccessToken) {
           self.cache.putActiveProfile(user);
@@ -115,7 +115,7 @@ export default class Authorize extends XQModule {
             this.serviceName,
             CallMethod.POST,
             null,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/AuthorizeAlias.ts
+++ b/src/com/xqmsg/sdk/v2/services/AuthorizeAlias.ts
@@ -34,10 +34,10 @@ export default class AuthorizeAlias extends XQModule {
   static USER: "user" = "user";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {String} maybePayLoad.user - Email of the user to be validated.
-   * @param {String} [maybePayLoad.firstName] - First name of the user. (Optional)
-   * @param {String} [maybePayLoad.lastName] - Last name of the user. (Optional)
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {String} maybePayload.user - Email of the user to be validated.
+   * @param {String} [maybePayload.firstName] - First name of the user. (Optional)
+   * @param {String} [maybePayload.lastName] - Last name of the user. (Optional)
    *
    * @returns {Promise<ServerResponse<{payload:string}>>}
    */
@@ -49,14 +49,14 @@ export default class AuthorizeAlias extends XQModule {
     this.serviceName = "authorizealias";
     this.requiredFields = [AuthorizeAlias.USER];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const self = this;
 
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
-
         const aliasUser =
-          maybePayLoad[AuthorizeAlias.USER as keyof IAuthorizeAliasParams] ??
+          maybePayload[AuthorizeAlias.USER as keyof IAuthorizeAliasParams] ??
           "";
 
         return this.sdk
@@ -65,7 +65,7 @@ export default class AuthorizeAlias extends XQModule {
             this.serviceName,
             CallMethod.POST,
             null,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/AuthorizeDelegate.ts
+++ b/src/com/xqmsg/sdk/v2/services/AuthorizeDelegate.ts
@@ -21,7 +21,7 @@ export default class AuthorizeDelegate extends XQModule {
 
   /**
    *
-   * @param {{}} [maybePayLoad=null]
+   * @param {{}} [maybePayload=null]
    * @returns {Promise<ServerResponse<{payload:string}>>}
    */
   supplyAsync: (maybePayload: null) => Promise<ServerResponse>;
@@ -32,8 +32,10 @@ export default class AuthorizeDelegate extends XQModule {
     this.serviceName = "delegate";
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const accessToken = this.sdk.validateAccessToken();
 
         const additionalHeaderProperties = {
@@ -46,7 +48,7 @@ export default class AuthorizeDelegate extends XQModule {
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/CheckApiKey.ts
+++ b/src/com/xqmsg/sdk/v2/services/CheckApiKey.ts
@@ -25,8 +25,8 @@ export default class CheckApiKey extends XQModule {
   static SCOPES: "scopes" = "scopes";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {String} maybePayLoad.api-key - The API key whose scopes are to be checked
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {String} maybePayload.api-key - The API key whose scopes are to be checked
    *
    * @returns {Promise<ServerResponse<{payload:{scopes:[string]}}>>}
    */
@@ -37,9 +37,9 @@ export default class CheckApiKey extends XQModule {
     this.serviceName = "apikey";
     this.requiredFields = [CheckApiKey.API_KEY];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
         const accessToken = this.sdk.validateAccessToken();
 
         const additionalHeaderProperties = {
@@ -52,7 +52,7 @@ export default class CheckApiKey extends XQModule {
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/CheckKeyExpiration.ts
+++ b/src/com/xqmsg/sdk/v2/services/CheckKeyExpiration.ts
@@ -25,8 +25,8 @@ export default class CheckKeyExpiration extends XQModule {
   static LOCATOR_KEY: "locatorKey" = "locatorKey";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {String} maybePayLoad.locatorKey- A URL encoded version of the key locator token to fetch the key from the server.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {String} maybePayload.locatorKey- A URL encoded version of the key locator token to fetch the key from the server.
    * @see #encodeURIComponent function encodeURIComponent (built-in since ES-5)
    * @returns {Promise<ServerResponse<{payload:{expiresOn:long}}>>}
    **/
@@ -40,12 +40,12 @@ export default class CheckKeyExpiration extends XQModule {
     this.serviceName = "expiration";
     this.requiredFields = [CheckKeyExpiration.LOCATOR_KEY];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
         const accessToken = this.sdk.validateAccessToken();
 
-        const locatorKey = maybePayLoad[CheckKeyExpiration.LOCATOR_KEY];
+        const locatorKey = maybePayload[CheckKeyExpiration.LOCATOR_KEY];
         const additionalHeaderProperties = {
           Authorization: "Bearer " + accessToken,
         };

--- a/src/com/xqmsg/sdk/v2/services/CodeValidator.ts
+++ b/src/com/xqmsg/sdk/v2/services/CodeValidator.ts
@@ -24,8 +24,8 @@ export default class CodeValidator extends XQModule {
   static PIN: "pin" = "pin";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {String} maybePayLoad.pin - the two-factor pin used to validate the `Authorize` service request
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {String} maybePayload.pin - the two-factor pin used to validate the `Authorize` service request
    *
    * @returns {Promise<ServerResponse<{payload:String}>>} a `ServerResponse` containing the access token
    */
@@ -37,10 +37,10 @@ export default class CodeValidator extends XQModule {
     this.serviceName = "codevalidation";
     this.requiredFields = [CodeValidator.PIN];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
         const self = this;
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
         const preAuthToken = this.sdk.validatePreAuthToken();
 
         const additionalHeaderProperties = {
@@ -53,7 +53,7 @@ export default class CodeValidator extends XQModule {
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/CombineAuthorizations.ts
+++ b/src/com/xqmsg/sdk/v2/services/CombineAuthorizations.ts
@@ -38,8 +38,8 @@ export default class CombineAuthorizations extends XQModule {
   /** The field name representing the list of tokens to merge */
   static TOKENS: "tokens" = "tokens";
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {[String]} maybePayLoad.tokens - The list of tokens to merge
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {[String]} maybePayload.tokens - The list of tokens to merge
    * @returns {Promise<ServerResponse<{payload:{token:string, merged:long}}>>}
    */
   supplyAsync: (maybePayload: { tokens: string[] }) => Promise<ServerResponse>;
@@ -50,9 +50,9 @@ export default class CombineAuthorizations extends XQModule {
     this.serviceName = "combined";
     this.requiredFields = [CombineAuthorizations.TOKENS];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
         const accessToken = this.sdk.validateAccessToken();
 
         const additionalHeaderProperties = {
@@ -64,7 +64,7 @@ export default class CombineAuthorizations extends XQModule {
             this.serviceName,
             CallMethod.POST,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/Decrypt.ts
+++ b/src/com/xqmsg/sdk/v2/services/Decrypt.ts
@@ -28,9 +28,9 @@ export default class Decrypt extends XQModule {
   /** The field name representing the key used to fetch the encryption key from the server */
   static LOCATOR_KEY: "locatorKey" = "locatorKey";
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {String} maybePayLoad.locatorKey - the key used to fetch the encryption key from the server
-   * @param {String} maybePayLoad.encryptedText  - the encrypted text to decrypt.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {String} maybePayload.locatorKey - the key used to fetch the encryption key from the server
+   * @param {String} maybePayload.encryptedText  - the encrypted text to decrypt.
    * @returns {Promise<ServerResponse<{payload:{decryptedText:string}}>>}
    */
   supplyAsync: (maybePayload: {
@@ -44,14 +44,14 @@ export default class Decrypt extends XQModule {
     this.algorithm = algorithm;
     this.requiredFields = [Decrypt.LOCATOR_KEY, Decrypt.ENCRYPTED_TEXT];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         // const accessToken = this.accessToken;
         const algorithm = this.algorithm;
-        const locatorKey = maybePayLoad[Decrypt.LOCATOR_KEY];
-        const encryptedText = maybePayLoad[Decrypt.ENCRYPTED_TEXT];
+        const locatorKey = maybePayload[Decrypt.LOCATOR_KEY];
+        const encryptedText = maybePayload[Decrypt.ENCRYPTED_TEXT];
 
         return new FetchKey(this.sdk)
           .supplyAsync({ [FetchKey.LOCATOR_KEY]: locatorKey })

--- a/src/com/xqmsg/sdk/v2/services/DeleteAuthorization.ts
+++ b/src/com/xqmsg/sdk/v2/services/DeleteAuthorization.ts
@@ -13,13 +13,16 @@ import handleException from "../exceptions/handleException";
  * @class [DeleteAuthorization]
  */
 export default class DeleteAuthorization extends XQModule {
+  /** The required fields of the payload needed to utilize the service */
+  requiredFields: string[];
+
   /** Specified name of the service */
   serviceName: string;
 
   /**
    *
    * @method supplyAsync
-   * @param {{}} [maybePayLoad=null]
+   * @param {{}} [maybePayload=null]
    * @returns {Promise<ServerResponse<{}>>}
    */
   supplyAsync: (maybePayload: null) => Promise<ServerResponse>;
@@ -27,9 +30,12 @@ export default class DeleteAuthorization extends XQModule {
   constructor(sdk: XQSDK) {
     super(sdk);
     this.serviceName = "authorization";
+    this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const accessToken = this.sdk.validateAccessToken();
 
         const additionalHeaderProperties = {
@@ -42,7 +48,7 @@ export default class DeleteAuthorization extends XQModule {
             this.serviceName,
             CallMethod.DELETE,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/DeleteSubscriber.ts
+++ b/src/com/xqmsg/sdk/v2/services/DeleteSubscriber.ts
@@ -13,22 +13,28 @@ import handleException from "../exceptions/handleException";
  * @class [DeleteSubscriber]
  */
 export default class DeleteSubscriber extends XQModule {
+  /** The required fields of the payload needed to utilize the service */
+  requiredFields: string[];
+
   /** Specified name of the service */
   serviceName: string;
 
   /**
    *
-   * @param {{}} [maybePayLoad=null]
+   * @param {{}} [maybePayload=null]
    * @returns {Promise<ServerResponse<{}>>}
    */
-  supplyAsync: (maybePayLoad: null) => Promise<ServerResponse>;
+  supplyAsync: (maybePayload: null) => Promise<ServerResponse>;
   constructor(sdk: XQSDK) {
     super(sdk);
 
     this.serviceName = "subscriber";
+    this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const accessToken = this.sdk.validateAccessToken();
 
         const additionalHeaderProperties = {
@@ -40,7 +46,7 @@ export default class DeleteSubscriber extends XQModule {
             this.serviceName,
             CallMethod.DELETE,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/Encrypt.ts
+++ b/src/com/xqmsg/sdk/v2/services/Encrypt.ts
@@ -62,20 +62,20 @@ export default class Encrypt extends XQModule {
   static META: "meta" = "meta";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {[String]} maybePayLoad.recipients  - the list of emails of users intended to have read access to the encrypted content
-   * @param {String} maybePayLoad.text - the text that will be encrypted
-   * @param {Number} maybePayLoad.expires - the number of hours of life span until access to the encrypted text is expired
-   * @param {Boolean} [maybePayLoad.dor=false] - an optional boolean value which specifies if the content should be deleted after opening
-   * @param {String} maybePayLoad.locatorKey - an optional string value that may be used to utilize a pre-existing locator key
-   * @param {String} maybePayLoad.encryptionKey - an optional string value that may be used to utilize a pre-existing encryption key
-   * @param {String} maybePayLoad.type - an optional string value which specifies the type of communication the user is encrypting. Defaults to `unknown`
-   * @param {Map} maybePayLoad.meta - an optional map value which can contain any arbitrary metadata the user wants
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {[String]} maybePayload.recipients  - the list of emails of users intended to have read access to the encrypted content
+   * @param {String} maybePayload.text - the text that will be encrypted
+   * @param {Number} maybePayload.expires - the number of hours of life span until access to the encrypted text is expired
+   * @param {Boolean} [maybePayload.dor=false] - an optional boolean value which specifies if the content should be deleted after opening
+   * @param {String} maybePayload.locatorKey - an optional string value that may be used to utilize a pre-existing locator key
+   * @param {String} maybePayload.encryptionKey - an optional string value that may be used to utilize a pre-existing encryption key
+   * @param {String} maybePayload.type - an optional string value which specifies the type of communication the user is encrypting. Defaults to `unknown`
+   * @param {Map} maybePayload.meta - an optional map value which can contain any arbitrary metadata the user wants
    *
    * @returns {Promise<ServerResponse<{payload:{locatorKey:string, encryptedText:string}}>>}
    */
   supplyAsync: (
-    maybePayLoad: IEncryptParams
+    maybePayload: IEncryptParams
   ) => Promise<ServerResponse | undefined>;
 
   constructor(sdk: XQSDK, algorithm: EncryptionAlgorithm) {
@@ -88,23 +88,23 @@ export default class Encrypt extends XQModule {
       Encrypt.EXPIRES_HOURS,
     ];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const sdk = this.sdk;
         const algorithm = this.algorithm;
-        const message = maybePayLoad[Encrypt.TEXT];
-        const recipients = maybePayLoad[Encrypt.RECIPIENTS];
-        const expiresHours = maybePayLoad[Encrypt.EXPIRES_HOURS];
+        const message = maybePayload[Encrypt.TEXT];
+        const recipients = maybePayload[Encrypt.RECIPIENTS];
+        const expiresHours = maybePayload[Encrypt.EXPIRES_HOURS];
         const deleteOnReceipt =
-          maybePayLoad[Encrypt.DELETE_ON_RECEIPT] ?? false;
+          maybePayload[Encrypt.DELETE_ON_RECEIPT] ?? false;
 
-        const locatorKey = maybePayLoad[Encrypt.LOCATOR_KEY];
-        const encryptionKey = maybePayLoad[Encrypt.ENCRYPTION_KEY];
+        const locatorKey = maybePayload[Encrypt.LOCATOR_KEY];
+        const encryptionKey = maybePayload[Encrypt.ENCRYPTION_KEY];
 
-        const type = maybePayLoad[Encrypt.TYPE] ?? CommunicationsEnum.UNKNOWN;
-        const meta = maybePayLoad[Encrypt.META] ?? null;
+        const type = maybePayload[Encrypt.TYPE] ?? CommunicationsEnum.UNKNOWN;
+        const meta = maybePayload[Encrypt.META] ?? null;
 
         /**
          * A function utilized to take an encryption key and encrypt textual data.

--- a/src/com/xqmsg/sdk/v2/services/ExchangeForAccessToken.ts
+++ b/src/com/xqmsg/sdk/v2/services/ExchangeForAccessToken.ts
@@ -14,7 +14,7 @@ export default class ExchangeForAccessToken extends XQModule {
   serviceName: string;
   requiredFields: string[];
   /**
-   * @param {Map} [maybePayLoad=null] - Container for the request parameters supplied to this method.
+   * @param {Map} [maybePayload=null] - Container for the request parameters supplied to this method.
    *
    * @returns {Promise<ServerResponse<{payload:String}>>}
    */
@@ -25,8 +25,10 @@ export default class ExchangeForAccessToken extends XQModule {
     this.serviceName = "exchange";
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const self = this;
 
         const preAuthToken = this.sdk.validatePreAuthToken();
@@ -41,7 +43,7 @@ export default class ExchangeForAccessToken extends XQModule {
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/FetchKey.ts
+++ b/src/com/xqmsg/sdk/v2/services/FetchKey.ts
@@ -29,11 +29,11 @@ export default class FetchKey extends XQModule {
   static LOCATOR_KEY: "locatorKey" = "locatorKey";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {String} maybePayLoad.locatorKey - the key used to fetch the encryption key from the server
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {String} maybePayload.locatorKey - the key used to fetch the encryption key from the server
    * @returns {Promise<ServerResponse<{payload:string}>>}
    */
-  supplyAsync: (maybePayLoad: {
+  supplyAsync: (maybePayload: {
     locatorKey: string;
   }) => Promise<ServerResponse>;
 
@@ -44,12 +44,12 @@ export default class FetchKey extends XQModule {
     this.serviceName = "key";
     this.requiredFields = [FetchKey.LOCATOR_KEY];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
         const accessToken = this.sdk.validateAccessToken();
 
-        const locatorKey = maybePayLoad[FetchKey.LOCATOR_KEY];
+        const locatorKey = maybePayload[FetchKey.LOCATOR_KEY];
         const additionalHeaderProperties = {
           Authorization: "Bearer " + accessToken,
         };

--- a/src/com/xqmsg/sdk/v2/services/FileDecrypt.ts
+++ b/src/com/xqmsg/sdk/v2/services/FileDecrypt.ts
@@ -23,8 +23,8 @@ export default class FileDecrypt extends XQModule {
   static SOURCE_FILE: "sourceFile" = "sourceFile";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {File} maybePayLoad.sourceFile - The file to be decrypted.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {File} maybePayload.sourceFile - The file to be decrypted.
    *
    *  @returns {Promise<ServerResponse<{payload:File}>>}
    */
@@ -36,9 +36,9 @@ export default class FileDecrypt extends XQModule {
     this.algorithm = algorithm;
     this.requiredFields = [FileDecrypt.SOURCE_FILE];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
       } catch (exception) {
         return new Promise((resolve) =>
           resolve(handleException(exception, XQServices.FileDecrypt))
@@ -46,7 +46,7 @@ export default class FileDecrypt extends XQModule {
       }
       const algorithm = this.algorithm;
       const sdk = this.sdk;
-      const sourceFile = maybePayLoad[FileDecrypt.SOURCE_FILE];
+      const sourceFile = maybePayload[FileDecrypt.SOURCE_FILE];
 
       try {
         return algorithm.decryptFile(

--- a/src/com/xqmsg/sdk/v2/services/FileEncrypt.ts
+++ b/src/com/xqmsg/sdk/v2/services/FileEncrypt.ts
@@ -62,17 +62,17 @@ export default class FileEncrypt extends XQModule {
   static META: "meta" = "meta";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {File} maybePayLoad.sourceFile - The file to be encrypted.
-   * @param {[String]} maybePayLoad.recipients  - List of emails of users intended to have read access to the encrypted content.
-   * @param {Long} maybePayLoad.expires - Life span of the encrypted content, measured in hours.
-   * @param {Boolean} [maybePayLoad.dor=false] - Should the content be deleted after opening.
-   * @param {String} maybePayLoad.type - an optional string value which specifies the type of communication the user is encrypting. Defaults to `unknown`
-   * @param {Map} maybePayLoad.meta - an optional map value which can contain any arbitrary metadata the user wants
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {File} maybePayload.sourceFile - The file to be encrypted.
+   * @param {[String]} maybePayload.recipients  - List of emails of users intended to have read access to the encrypted content.
+   * @param {Long} maybePayload.expires - Life span of the encrypted content, measured in hours.
+   * @param {Boolean} [maybePayload.dor=false] - Should the content be deleted after opening.
+   * @param {String} maybePayload.type - an optional string value which specifies the type of communication the user is encrypting. Defaults to `unknown`
+   * @param {Map} maybePayload.meta - an optional map value which can contain any arbitrary metadata the user wants
    *
    * @returns {Promise<ServerResponse<{payload:File}>>}
    */
-  supplyAsync: (maybePayLoad: IFileEncryptParams) => Promise<ServerResponse>;
+  supplyAsync: (maybePayload: IFileEncryptParams) => Promise<ServerResponse>;
 
   constructor(sdk: XQSDK, algorithm: EncryptionAlgorithm) {
     super(sdk);
@@ -84,20 +84,20 @@ export default class FileEncrypt extends XQModule {
       FileEncrypt.EXPIRES_HOURS,
     ];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const algorithm = this.algorithm;
         const sdk = this.sdk;
-        const deleteOnReceipt = maybePayLoad[FileEncrypt.DELETE_ON_RECEIPT];
-        const expiration = maybePayLoad[FileEncrypt.EXPIRES_HOURS];
-        const recipients = maybePayLoad[FileEncrypt.RECIPIENTS];
-        const sourceFile = maybePayLoad[FileEncrypt.SOURCE_FILE];
+        const deleteOnReceipt = maybePayload[FileEncrypt.DELETE_ON_RECEIPT];
+        const expiration = maybePayload[FileEncrypt.EXPIRES_HOURS];
+        const recipients = maybePayload[FileEncrypt.RECIPIENTS];
+        const sourceFile = maybePayload[FileEncrypt.SOURCE_FILE];
 
         const type =
-          maybePayLoad[FileEncrypt.TYPE] ?? CommunicationsEnum.UNKNOWN;
-        const meta = maybePayLoad[FileEncrypt.META] ?? null;
+          maybePayload[FileEncrypt.TYPE] ?? CommunicationsEnum.UNKNOWN;
+        const meta = maybePayload[FileEncrypt.META] ?? null;
 
         return new FetchQuantumEntropy(sdk)
           .supplyAsync({ [FetchQuantumEntropy.KS]: FetchQuantumEntropy._256 })

--- a/src/com/xqmsg/sdk/v2/services/GeneratePacket.ts
+++ b/src/com/xqmsg/sdk/v2/services/GeneratePacket.ts
@@ -47,13 +47,13 @@ export default class GeneratePacket extends XQModule {
   static META: "meta" = "meta";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {String} maybePayLoad.key - The secret key that the user wants to protect.
-   * @param {Long} maybePayLoad.expires - The number of hours that this key will remain valid for. After this time, it will no longer be accessible.
-   * @param {[String]} maybePayLoad.recipients  -  list of emails of those recipients who are allowed to access the key.
-   * @param {Boolean} [maybePayLoad.dor=false] - Should the content be deleted after opening.
-   * @param {String} maybePayLoad.type - an optional string value which specifies the type of communication the user is encrypting. Defaults to `unknown`
-   * @param {Map} maybePayLoad.meta - an optional map value which can contain any arbitrary metadata the user wants
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {String} maybePayload.key - The secret key that the user wants to protect.
+   * @param {Long} maybePayload.expires - The number of hours that this key will remain valid for. After this time, it will no longer be accessible.
+   * @param {[String]} maybePayload.recipients  -  list of emails of those recipients who are allowed to access the key.
+   * @param {Boolean} [maybePayload.dor=false] - Should the content be deleted after opening.
+   * @param {String} maybePayload.type - an optional string value which specifies the type of communication the user is encrypting. Defaults to `unknown`
+   * @param {Map} maybePayload.meta - an optional map value which can contain any arbitrary metadata the user wants
    *
    * @returns {Promise<ServerResponse<{payload:string}>>}
    */
@@ -69,9 +69,9 @@ export default class GeneratePacket extends XQModule {
       GeneratePacket.EXPIRES_HOURS,
     ];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
         const accessToken = this.sdk.validateAccessToken();
 
         const additionalHeaderProperties = {
@@ -79,10 +79,10 @@ export default class GeneratePacket extends XQModule {
         };
 
         const flattenedRecipientList =
-          maybePayLoad[GeneratePacket.RECIPIENTS].join(",");
+          maybePayload[GeneratePacket.RECIPIENTS].join(",");
 
         const payload = {
-          ...maybePayLoad,
+          ...maybePayload,
           [GeneratePacket.RECIPIENTS]: flattenedRecipientList,
         };
 

--- a/src/com/xqmsg/sdk/v2/services/GetSettings.ts
+++ b/src/com/xqmsg/sdk/v2/services/GetSettings.ts
@@ -25,7 +25,7 @@ export default class GetSettings extends XQModule {
   static NOTIFICATIONS: "notifications" = "notifications";
 
   /**
-   * @param {{}} [maybePayLoad=null]
+   * @param {{}} [maybePayload=null]
    * @returns {Promise<ServerResponse<{payload:{notifications:NotificationEnum.options, newsLetter:boolean}}>>}
    */
   supplyAsync: (maybePayload: null) => Promise<ServerResponse>;
@@ -35,8 +35,10 @@ export default class GetSettings extends XQModule {
     this.serviceName = "settings";
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const accessToken = this.sdk.validateAccessToken();
 
         const additionalHeaderProperties = {
@@ -49,7 +51,7 @@ export default class GetSettings extends XQModule {
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/GetSubscriberInfo.ts
+++ b/src/com/xqmsg/sdk/v2/services/GetSubscriberInfo.ts
@@ -40,7 +40,7 @@ export default class GetSubscriberInfo extends XQModule {
   static USER: "user" = "user";
 
   /**
-   * @param {Map} [maybePayLoad=null]
+   * @param {Map} [maybePayload=null]
    * @returns {Promise<ServerResponse<{payload:{id:long, usr:string, firstName:string, sub:string, starts:long, ends:Long}}>>}
    */
   supplyAsync: (maybePayload: null) => Promise<ServerResponse>;
@@ -51,8 +51,10 @@ export default class GetSubscriberInfo extends XQModule {
     this.serviceName = "subscriber";
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const accessToken = this.sdk.validateAccessToken();
 
         const additionalHeaderProperties = {
@@ -65,7 +67,7 @@ export default class GetSubscriberInfo extends XQModule {
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/GrantUserAccess.ts
+++ b/src/com/xqmsg/sdk/v2/services/GrantUserAccess.ts
@@ -26,9 +26,9 @@ export default class GrantUserAccess extends XQModule {
   static RECIPIENTS: "recipients" = "recipients";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {[String]} maybePayLoad.recipients  - the list of emails of users intended to have read access to the encrypted content
-   * @param {String} maybePayLoad.locatorToken - a URL encoded version of the key locator token to fetch the key from the server.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {[String]} maybePayload.recipients  - the list of emails of users intended to have read access to the encrypted content
+   * @param {String} maybePayload.locatorToken - a URL encoded version of the key locator token to fetch the key from the server.
    * @see #encodeURIComponent function encodeURIComponent (built-in since ES-5)
    * @returns {Promise<ServerResponse<{payload:{data:{}}}>>}
    */
@@ -46,16 +46,16 @@ export default class GrantUserAccess extends XQModule {
       GrantUserAccess.RECIPIENTS,
     ];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
         const accessToken = this.sdk.validateAccessToken();
 
         const flattenedRecipientList =
-          maybePayLoad[GrantUserAccess.RECIPIENTS].join(",");
+          maybePayload[GrantUserAccess.RECIPIENTS].join(",");
 
         const payload = {
-          ...maybePayLoad,
+          ...maybePayload,
           [GrantUserAccess.RECIPIENTS]: flattenedRecipientList,
         };
 
@@ -68,7 +68,7 @@ export default class GrantUserAccess extends XQModule {
             this.sdk.VALIDATION_SERVER_URL,
             this.serviceName +
               "/" +
-              encodeURIComponent(maybePayLoad[GrantUserAccess.LOCATOR_TOKEN]),
+              encodeURIComponent(maybePayload[GrantUserAccess.LOCATOR_TOKEN]),
             CallMethod.POST,
             additionalHeaderProperties,
             payload,

--- a/src/com/xqmsg/sdk/v2/services/RevokeKeyAccess.ts
+++ b/src/com/xqmsg/sdk/v2/services/RevokeKeyAccess.ts
@@ -23,8 +23,8 @@ export default class RevokeKeyAccess extends XQModule {
   static LOCATOR_KEYS: "locatorKeys" = "locatorKeys";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {[String]} maybePayLoad.locatorKey - the locator key used as a URL to discover the key on the server.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {[String]} maybePayload.locatorKey - the locator key used as a URL to discover the key on the server.
    * The URL encoding part is handled internally in the service itself
    * @see #encodeURIComponent function encodeURIComponent (built-in since ES-5)
    * @returns {Promise<ServerResponse<{}>>}
@@ -39,11 +39,11 @@ export default class RevokeKeyAccess extends XQModule {
     this.serviceName = "key";
     this.requiredFields = [RevokeKeyAccess.LOCATOR_KEYS];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
         const accessToken = this.sdk.validateAccessToken();
-        const locatorKeys = maybePayLoad[RevokeKeyAccess.LOCATOR_KEYS];
+        const locatorKeys = maybePayload[RevokeKeyAccess.LOCATOR_KEYS];
 
         const additionalHeaderProperties = {
           Authorization: "Bearer " + accessToken,

--- a/src/com/xqmsg/sdk/v2/services/RevokeUserAccess.ts
+++ b/src/com/xqmsg/sdk/v2/services/RevokeUserAccess.ts
@@ -25,9 +25,9 @@ export default class RevokeUserAccess extends XQModule {
   static LOCATOR_KEY: "locatorKey" = "locatorKey";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {[String]} maybePayLoad.recipients! - the list of emails of users intended to have read access to the encrypted content removed.<br>
-   * @param {String} maybePayLoad.locatorKey! - thelocator key,  used as a URL to discover the key on  the server.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {[String]} maybePayload.recipients! - the list of emails of users intended to have read access to the encrypted content removed.<br>
+   * @param {String} maybePayload.locatorKey! - thelocator key,  used as a URL to discover the key on  the server.
    * The URL encoding part is handled internally in the service itself
    * @see #encodeURIComponent function encodeURIComponent (built-in since ES-5)
    * @returns {Promise<ServerResponse<{}>>}
@@ -46,18 +46,18 @@ export default class RevokeUserAccess extends XQModule {
       RevokeUserAccess.LOCATOR_KEY,
     ];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
         const accessToken = this.sdk.validateAccessToken();
 
-        const locatorKey = maybePayLoad[RevokeUserAccess.LOCATOR_KEY];
+        const locatorKey = maybePayload[RevokeUserAccess.LOCATOR_KEY];
 
         const flattenedRecipientList =
-          maybePayLoad[RevokeUserAccess.RECIPIENTS].join(",");
+          maybePayload[RevokeUserAccess.RECIPIENTS].join(",");
 
         const payload = {
-          ...maybePayLoad,
+          ...maybePayload,
           [RevokeUserAccess.RECIPIENTS]: flattenedRecipientList,
         };
 

--- a/src/com/xqmsg/sdk/v2/services/UpdateSettings.ts
+++ b/src/com/xqmsg/sdk/v2/services/UpdateSettings.ts
@@ -25,9 +25,9 @@ export default class UpdateSettings extends XQModule {
 
   /**
    *
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {boolean} maybePayLoad.newsLetter - the boolean indicating whether the user receive newsletters or not. This is only valid for new users, and is ignored if the user already exists
-   * @param {NotificationEnum.options} maybePayLoad.notifications - the boolean indicating whether the user receive notifications or not
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {boolean} maybePayload.newsLetter - the boolean indicating whether the user receive newsletters or not. This is only valid for new users, and is ignored if the user already exists
+   * @param {NotificationEnum.options} maybePayload.notifications - the boolean indicating whether the user receive notifications or not
    * @returns {Promise<ServerResponse<{}>>}
    */
   supplyAsync: (maybePayload: {
@@ -41,8 +41,10 @@ export default class UpdateSettings extends XQModule {
     this.serviceName = "settings";
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const accessToken = this.sdk.validateAccessToken();
 
         const additionalHeaderProperties = {
@@ -55,7 +57,7 @@ export default class UpdateSettings extends XQModule {
             this.serviceName,
             CallMethod.PATCH,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/sdk/v2/services/dashboard/AddApplication.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/AddApplication.ts
@@ -26,7 +26,7 @@ export default class AddApplication extends XQModule {
   static DESC: "desc" = "desc";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @param {String} name - the name of the application
    * @param {String} desc - the description of the application
    * @returns {Promise<ServerResponse<{payload:{id: int}}>>}
@@ -41,8 +41,10 @@ export default class AddApplication extends XQModule {
     this.serviceName = "devapp";
     this.requiredFields = [AddApplication.NAME];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );
@@ -57,7 +59,7 @@ export default class AddApplication extends XQModule {
             this.serviceName,
             CallMethod.POST,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true,
             Destination.DASHBOARD
           )

--- a/src/com/xqmsg/sdk/v2/services/dashboard/AddBusiness.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/AddBusiness.ts
@@ -67,7 +67,7 @@ export default class AddBusiness extends XQModule {
   static CONVERT_FROM_EXISTING: "convertFromExisting" = "convertFromExisting";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @param {String} email - the main business email
    * @param {String} workspace - the desired workspace for the business
    * @param {String} name - the name of the business
@@ -84,7 +84,7 @@ export default class AddBusiness extends XQModule {
    * @param {Boolean} convertFromExisting - the flag for whether or not to convert the existing dashboard into the newly created dashboard
    * @returns {Promise<ServerResponse<{payload: string}>>} - payload is the access token for the new business
    */
-  supplyAsync: (maybePayLoad: {
+  supplyAsync: (maybePayload: {
     [AddBusiness.EMAIL]: string;
     [AddBusiness.WORKSPACE]: string;
     [AddBusiness.NAME]: string;
@@ -111,9 +111,9 @@ export default class AddBusiness extends XQModule {
       AddBusiness.WORKSPACE,
     ];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
@@ -129,7 +129,7 @@ export default class AddBusiness extends XQModule {
             this.serviceName,
             CallMethod.POST,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true,
             Destination.DASHBOARD
           )

--- a/src/com/xqmsg/sdk/v2/services/dashboard/AddContact.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/AddContact.ts
@@ -41,13 +41,13 @@ export default class AddContact extends XQModule {
   static TITLE: "title" = "title";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @param {String} email - the email of the new Contact
    * @param {String} role - the role of the new Contact
    * @param {String} notifications - the notifications preference of the current user for the new Contact
    * @returns {Promise<ServerResponse<{payload:{id:int, status:string}}>>}
    */
-  supplyAsync: (maybePayLoad: {
+  supplyAsync: (maybePayload: {
     email: string;
     role: string;
     notifications: boolean;
@@ -62,9 +62,9 @@ export default class AddContact extends XQModule {
       AddContact.NOTIFICATIONS,
     ];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
@@ -80,7 +80,7 @@ export default class AddContact extends XQModule {
             this.serviceName,
             CallMethod.POST,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true,
             Destination.DASHBOARD
           )

--- a/src/com/xqmsg/sdk/v2/services/dashboard/AddUserGroup.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/AddUserGroup.ts
@@ -29,11 +29,11 @@ export default class AddUserGroup extends XQModule {
   static NAME: "name" = "name";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {[String]} maybePayLoad.name - the name of the user group
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {[String]} maybePayload.name - the name of the user group
    * @returns {Promise<ServerResponse<{}>>}
    */
-  supplyAsync: (maybePayLoad: { name: string }) => Promise<ServerResponse>;
+  supplyAsync: (maybePayload: { name: string }) => Promise<ServerResponse>;
 
   constructor(sdk: XQSDK) {
     super(sdk);
@@ -41,13 +41,13 @@ export default class AddUserGroup extends XQModule {
     this.requiredFields = [AddUserGroup.NAME];
 
     /**
-     * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+     * @param {Map} maybePayload - the container for the request parameters supplied to this method.
      * @param {String} name - the name of the new group
      * @returns {Promise<ServerResponse<{payload:{id:int, status:string}}>>}
      */
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
@@ -63,7 +63,7 @@ export default class AddUserGroup extends XQModule {
             this.serviceName,
             CallMethod.POST,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true,
             Destination.DASHBOARD
           )

--- a/src/com/xqmsg/sdk/v2/services/dashboard/DashboardLogin.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/DashboardLogin.ts
@@ -27,11 +27,11 @@ export default class DashboardLogin extends XQModule {
   static PWD: "pwd" = "pwd";
 
   /**
-   * @param {Map} maybePayLoad - the container for the request parameters supplied to this method.
-   * @param {String} maybePayLoad.pwd - the provided OAuth token
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {String} maybePayload.pwd - the provided OAuth token
    * @returns {Promise<ServerResponse<{payload:string}>>}
    */
-  supplyAsync: (maybePayLoad: {
+  supplyAsync: (maybePayload: {
     [DashboardLogin.PWD]: string;
   }) => Promise<ServerResponse>;
 
@@ -40,14 +40,14 @@ export default class DashboardLogin extends XQModule {
     this.serviceName = DashboardLogin.LOGIN;
     this.requiredFields = [DashboardLogin.PWD];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
         const self = this;
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
 
         const loginRequest = {
           method: 1, // TODO(worstestes - 3.21.22): an obselete field which will be removed at a later date
-          [DashboardLogin.PWD]: maybePayLoad.pwd,
+          [DashboardLogin.PWD]: maybePayload.pwd,
         };
 
         return this.sdk

--- a/src/com/xqmsg/sdk/v2/services/dashboard/DisableContact.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/DisableContact.ts
@@ -22,20 +22,20 @@ export default class DisableContact extends XQModule {
   static ID: "id" = "id";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @param {String} id - the user id of the Contact that will be disabled
    * @returns {Promise<ServerResponse<{payload:{id:int, status:string}}>>}
    */
-  supplyAsync: (maybePayLoad: { id: string }) => Promise<ServerResponse>;
+  supplyAsync: (maybePayload: { id: string }) => Promise<ServerResponse>;
 
   constructor(sdk: XQSDK) {
     super(sdk);
     this.serviceName = "contact";
     this.requiredFields = [DisableContact.ID];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
@@ -48,7 +48,7 @@ export default class DisableContact extends XQModule {
         return this.sdk
           .call(
             this.sdk.DASHBOARD_SERVER_URL,
-            `${this.serviceName}/${maybePayLoad[DisableContact.ID]}`,
+            `${this.serviceName}/${maybePayload[DisableContact.ID]}`,
             CallMethod.DELETE,
             additionalHeaderProperties,
             null,

--- a/src/com/xqmsg/sdk/v2/services/dashboard/FindUserGroups.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/FindUserGroups.ts
@@ -27,7 +27,7 @@ export default class FindUserGroups extends XQModule {
   static ID: "id" = "id";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @returns {Promise<ServerResponse<{payload:{groups:[{id:int, name:string, bid:int}]}}>>}
    */
   supplyAsync: (maybePayload: null) => Promise<ServerResponse>;
@@ -37,8 +37,10 @@ export default class FindUserGroups extends XQModule {
     this.serviceName = "usergroup";
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );
@@ -53,7 +55,7 @@ export default class FindUserGroups extends XQModule {
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true,
             Destination.DASHBOARD
           )

--- a/src/com/xqmsg/sdk/v2/services/dashboard/GetApplications.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/GetApplications.ts
@@ -23,7 +23,7 @@ export default class GetApplications extends XQModule {
   static APPS: "apps" = "apps";
 
   /**
-   * @param {{}} [maybePayLoad=null]
+   * @param {{}} [maybePayload=null]
    * @returns {Promise<ServerResponse<{payload:{apps:[{id:int, name:string, description:string}]}}>>}
    */
   supplyAsync: (maybePayload: null) => Promise<ServerResponse>;
@@ -33,8 +33,10 @@ export default class GetApplications extends XQModule {
     this.serviceName = "devapps";
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );
@@ -49,7 +51,7 @@ export default class GetApplications extends XQModule {
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true,
             Destination.DASHBOARD
           )

--- a/src/com/xqmsg/sdk/v2/services/dashboard/GetBusinesses.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/GetBusinesses.ts
@@ -22,7 +22,7 @@ export default class GetBusinesses extends XQModule {
   static BUSINESSES: "businesses" = "businesses";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    *
    * @returns {Promise<ServerResponse<{payload:{businesses:[{canAccessBusiness: boolean, domain: string, id: int, isPersonal: boolean, name: string}]}}>>}
    */
@@ -34,8 +34,10 @@ export default class GetBusinesses extends XQModule {
     this.requiredFields = [];
 
     // TODO(joshuaskatz - 3.22.22): add filter capabilities
-    this.supplyAsync = () => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );

--- a/src/com/xqmsg/sdk/v2/services/dashboard/GetCommunications.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/GetCommunications.ts
@@ -56,7 +56,7 @@ export default class GetCommunications extends XQModule {
   static TZ: "tz" = "tz";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @returns {Promise<ServerResponse<{payload: EventLogItem[] }>>}
    */
   supplyAsync: (
@@ -80,8 +80,10 @@ export default class GetCommunications extends XQModule {
     this.serviceName = GetCommunications.COMMUNICATIONS;
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayload) => {
+    this.supplyAsync = (maybePayload = {}) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );

--- a/src/com/xqmsg/sdk/v2/services/dashboard/GetContacts.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/GetContacts.ts
@@ -39,7 +39,7 @@ export default class GetContacts extends XQModule {
   static ROLE: "role" = "role";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @returns {Promise<ServerResponse<{payload: ContactSummary }>>}
    */
   supplyAsync: (
@@ -58,8 +58,10 @@ export default class GetContacts extends XQModule {
     this.requiredFields = [];
 
     // TODO(worstestes - 3.21.22): add filter capabilities
-    this.supplyAsync = () => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );

--- a/src/com/xqmsg/sdk/v2/services/dashboard/GetCurrentBusiness.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/GetCurrentBusiness.ts
@@ -20,19 +20,19 @@ export default class GetCurrentBusiness extends XQModule {
   serviceName: string;
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @returns {Promise<ServerResponse<{payload: CurrentBusinessSummary}>>}
    */
-  supplyAsync: (maybePayLoad: null) => Promise<ServerResponse>;
+  supplyAsync: (maybePayload: null) => Promise<ServerResponse>;
 
   constructor(sdk: XQSDK) {
     super(sdk);
     this.serviceName = "business";
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
@@ -48,7 +48,7 @@ export default class GetCurrentBusiness extends XQModule {
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true,
             Destination.DASHBOARD
           )

--- a/src/com/xqmsg/sdk/v2/services/dashboard/GetCurrentUser.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/GetCurrentUser.ts
@@ -23,7 +23,7 @@ export default class GetCurrentUser extends XQModule {
   static CONTACT: "contact" = "contact";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @returns {Promise<ServerResponse<{payload: ContactSummary }>>}
    */
   supplyAsync: (maybePayload: null) => Promise<ServerResponse>;
@@ -33,8 +33,10 @@ export default class GetCurrentUser extends XQModule {
     this.serviceName = GetCurrentUser.CONTACT;
     this.requiredFields = [];
 
-    this.supplyAsync = () => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const self = this;
 
         const dashboardAccessToken = this.sdk.validateAccessToken(

--- a/src/com/xqmsg/sdk/v2/services/dashboard/GetEventLogs.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/GetEventLogs.ts
@@ -59,7 +59,7 @@ export default class GetEventLogs extends XQModule {
   static FULL: "full" = "full";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @returns {Promise<ServerResponse<{payload: EventLogItem[] }>>}
    */
   supplyAsync: (
@@ -86,6 +86,8 @@ export default class GetEventLogs extends XQModule {
 
     this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );

--- a/src/com/xqmsg/sdk/v2/services/dashboard/GetEventTypes.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/GetEventTypes.ts
@@ -19,22 +19,21 @@ export default class GetEventTypes extends XQModule {
   /** Specified name of the service */
   serviceName: string;
 
-  /** The service name */
-  static EVENT_TYPES: "eventtypes" = "eventtypes";
-
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @returns {Promise<ServerResponse<{payload: EventType[] }>>}
    */
-  supplyAsync: () => Promise<ServerResponse>;
+  supplyAsync: (maybePayload: null) => Promise<ServerResponse>;
 
   constructor(sdk: XQSDK) {
     super(sdk);
-    this.serviceName = GetEventTypes.EVENT_TYPES;
+    this.serviceName = "eventtypes";
     this.requiredFields = [];
 
-    this.supplyAsync = () => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );

--- a/src/com/xqmsg/sdk/v2/services/dashboard/RemoveApplication.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/RemoveApplication.ts
@@ -23,8 +23,8 @@ export default class RemoveApplication extends XQModule {
   static ID: "id" = "id";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {Number} id - the id of the application
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {Number} maybePayload.id - the id of the application
    * @returns {Promise<ServerResponse<{payload:{}}>>}
    */
   supplyAsync: (maybePayload: {
@@ -36,8 +36,10 @@ export default class RemoveApplication extends XQModule {
     this.serviceName = "devapp";
     this.requiredFields = [RemoveApplication.ID];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );
@@ -49,7 +51,7 @@ export default class RemoveApplication extends XQModule {
         return this.sdk
           .call(
             this.sdk.DASHBOARD_SERVER_URL,
-            this.serviceName + "/" + maybePayLoad[RemoveApplication.ID],
+            this.serviceName + "/" + maybePayload[RemoveApplication.ID],
             CallMethod.DELETE,
             additionalHeaderProperties,
             null,

--- a/src/com/xqmsg/sdk/v2/services/dashboard/RemoveContact.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/RemoveContact.ts
@@ -23,7 +23,7 @@ export default class RemoveContact extends XQModule {
   static ID: "id" = "id";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @param {String} id - the user id of the Contact that will be removed
    * @returns {Promise<ServerResponse<{payload:{}}>>}
    */
@@ -36,9 +36,9 @@ export default class RemoveContact extends XQModule {
     this.serviceName = "contact";
     this.requiredFields = [RemoveContact.ID];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
@@ -51,7 +51,7 @@ export default class RemoveContact extends XQModule {
         return this.sdk
           .call(
             this.sdk.DASHBOARD_SERVER_URL,
-            `${this.serviceName}/${maybePayLoad[RemoveContact.ID]}?delete=true`,
+            `${this.serviceName}/${maybePayload[RemoveContact.ID]}?delete=true`,
             CallMethod.DELETE,
             additionalHeaderProperties,
             null,

--- a/src/com/xqmsg/sdk/v2/services/dashboard/RemoveUserGroup.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/RemoveUserGroup.ts
@@ -23,7 +23,7 @@ export default class RemoveUserGroup extends XQModule {
   static ID: "id" = "id";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @returns {Promise<ServerResponse<{payload:{}>>}
    */
   supplyAsync: (maybePayload: { id: string }) => Promise<ServerResponse>;
@@ -33,9 +33,9 @@ export default class RemoveUserGroup extends XQModule {
     this.serviceName = "usergroup";
     this.requiredFields = [RemoveUserGroup.ID];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
@@ -48,7 +48,7 @@ export default class RemoveUserGroup extends XQModule {
         return this.sdk
           .call(
             this.sdk.DASHBOARD_SERVER_URL,
-            this.serviceName + "/" + maybePayLoad[RemoveUserGroup.ID],
+            this.serviceName + "/" + maybePayload[RemoveUserGroup.ID],
             CallMethod.DELETE,
             additionalHeaderProperties,
             null,

--- a/src/com/xqmsg/sdk/v2/services/dashboard/UpdateApplication.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/UpdateApplication.ts
@@ -29,10 +29,10 @@ export default class UpdateApplication extends XQModule {
   static DESC: "desc" = "desc";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
-   * @param {Number} id - the id of the application
-   * @param {String} name - the name of the application
-   * @param {String} desc - the description of the application
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {Number} maybePayload.id - the id of the application
+   * @param {String} maybePayload.name - the name of the application
+   * @param {String} maybePayload.desc - the description of the application
    * @returns {Promise<ServerResponse<{payload:{}}>>}
    */
   supplyAsync: (maybePayload: {
@@ -46,8 +46,10 @@ export default class UpdateApplication extends XQModule {
     this.serviceName = "devapp";
     this.requiredFields = [UpdateApplication.ID];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );
@@ -59,10 +61,10 @@ export default class UpdateApplication extends XQModule {
         return this.sdk
           .call(
             this.sdk.DASHBOARD_SERVER_URL,
-            this.serviceName + "/" + maybePayLoad[UpdateApplication.ID],
+            this.serviceName + "/" + maybePayload[UpdateApplication.ID],
             CallMethod.PATCH,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true,
             Destination.DASHBOARD
           )

--- a/src/com/xqmsg/sdk/v2/services/dashboard/UpdateBusiness.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/UpdateBusiness.ts
@@ -52,7 +52,7 @@ export default class UpdateBusiness extends XQModule {
   static LOCKED: "locked" = "locked";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @param {String} email - the main business email
    * @param {String} name - the name of the business
    * @param {String} street - the street address of the business
@@ -65,7 +65,7 @@ export default class UpdateBusiness extends XQModule {
    * @param {Boolean} locked - the flag for whether or the business is locked.
    * @returns {Promise<ServerResponse<{payload:{}}>>}
    */
-  supplyAsync: (maybePayLoad: {
+  supplyAsync: (maybePayload: {
     [UpdateBusiness.EMAIL]?: string;
     [UpdateBusiness.NAME]?: string;
     [UpdateBusiness.STREET]?: string;
@@ -83,9 +83,9 @@ export default class UpdateBusiness extends XQModule {
     this.serviceName = "business";
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
@@ -101,7 +101,7 @@ export default class UpdateBusiness extends XQModule {
             this.serviceName,
             CallMethod.PATCH,
             additionalHeaderProperties,
-            maybePayLoad,
+            maybePayload,
             true,
             Destination.DASHBOARD
           )

--- a/src/com/xqmsg/sdk/v2/services/dashboard/UpdateUserGroup.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/UpdateUserGroup.ts
@@ -29,7 +29,7 @@ export default class UpdateUserGroup extends XQModule {
   static NAME: "name" = "name";
 
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @param {String} id - the id of the user group to be updated
    * @param {String} name - the updated name of the user group
    * @param {String} members - the updated members of the user group
@@ -46,9 +46,9 @@ export default class UpdateUserGroup extends XQModule {
     this.serviceName = "usergroup";
     this.requiredFields = [UpdateUserGroup.ID];
 
-    this.supplyAsync = (maybePayLoad) => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        this.sdk.validateInput(maybePayLoad, this.requiredFields);
+        this.sdk.validateInput(maybePayload, this.requiredFields);
 
         const dashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
@@ -59,14 +59,14 @@ export default class UpdateUserGroup extends XQModule {
         };
 
         const payload = {
-          [UpdateUserGroup.NAME]: maybePayLoad[UpdateUserGroup.NAME],
-          [UpdateUserGroup.MEMBERS]: maybePayLoad[UpdateUserGroup.MEMBERS],
+          [UpdateUserGroup.NAME]: maybePayload[UpdateUserGroup.NAME],
+          [UpdateUserGroup.MEMBERS]: maybePayload[UpdateUserGroup.MEMBERS],
         };
 
         return this.sdk
           .call(
             this.sdk.DASHBOARD_SERVER_URL,
-            this.serviceName + "/" + maybePayLoad[UpdateUserGroup.ID],
+            this.serviceName + "/" + maybePayload[UpdateUserGroup.ID],
             CallMethod.PATCH,
             additionalHeaderProperties,
             payload,

--- a/src/com/xqmsg/sdk/v2/services/dashboard/ValidateSession.ts
+++ b/src/com/xqmsg/sdk/v2/services/dashboard/ValidateSession.ts
@@ -18,22 +18,40 @@ export default class ValidateSession extends XQModule {
   /** Specified name of the service */
   serviceName: string;
 
+  /** The field name representing an access token */
+  static ACCESS_TOKEN: "accessToken" = "accessToken";
+
   /**
-   * @param {Map} maybePayLoad - Container for the request parameters supplied to this method.
+   * @param {Map} maybePayload - the container for the request parameters supplied to this method.
+   * @param {String} maybePayload.accesstoken - the provided access token
    * @returns {Promise<ServerResponse<{payload: string; status: ServerResponse.OK | ServerResponse.ERROR; statusCode: number; }>>}
    */
-  supplyAsync: () => Promise<ServerResponse>;
+  supplyAsync: (maybePayload: {
+    accessToken?: string;
+  }) => Promise<ServerResponse>;
 
   constructor(sdk: XQSDK) {
     super(sdk);
     this.serviceName = "session";
     this.requiredFields = [];
 
-    this.supplyAsync = () => {
+    this.supplyAsync = (maybePayload) => {
       try {
-        const dashboardAccessToken = this.sdk.validateAccessToken(
+        this.sdk.validateInput(maybePayload, this.requiredFields);
+
+        // the `suppliedDashboardAccessToken` is the (optional) provided access token to test against
+        const suppliedDashboardAccessToken =
+          maybePayload[ValidateSession.ACCESS_TOKEN];
+
+        // the `savedDashboardAccessToken` is the dashboard access token that may be saved in-memory
+        const savedDashboardAccessToken = this.sdk.validateAccessToken(
           Destination.DASHBOARD
         );
+
+        // we default to the supplied access token if provided, else we test against the saved, in-memory access token
+        const dashboardAccessToken = suppliedDashboardAccessToken
+          ? suppliedDashboardAccessToken
+          : savedDashboardAccessToken;
 
         const additionalHeaderProperties = {
           Authorization: "Bearer " + dashboardAccessToken,

--- a/src/com/xqmsg/sdk/v2/utils/verifyJWTExpiration.ts
+++ b/src/com/xqmsg/sdk/v2/utils/verifyJWTExpiration.ts
@@ -1,0 +1,16 @@
+/**
+ * A utility function used to determine whether an JWT is expired or not.
+ * @note - this function does not verify the JWT signature is valid and optional expiration, audience, or issuer are valid.
+ * @param token - a string value representing the JWT
+ * @returns boolean
+ */
+const verifyJWTExpiration = (token: string): boolean => {
+  const payloadBase64 = token.split(".")[1];
+  const decodedJson = Buffer.from(payloadBase64, "base64").toString();
+  const decoded = JSON.parse(decodedJson);
+  const exp = decoded.exp;
+  const expired = Date.now() >= exp * 1000;
+  return expired;
+};
+
+export default verifyJWTExpiration;


### PR DESCRIPTION
Problem
* `VerifyAccount` doesn't actually validate the provided access token from the user, it simply adds it to the SDKs in-memory cache. We want to ensure we validate the access token to ensure it's still valid. Note that this isn't a security issue as if the user + profile provided to the SDK service `VerifyAccount` is invalid/malformed, the SDK will throw when attempting to use another service
* We need to ensure `validateInput` method is utilized in every service, regardless of the expected `requiredFields` + provided `maybePayload` value

Solution
* Add `ValidateSession` service call from within `VerifyAccount` process
* Add `validateInput` call within each `supplyAsync` method body to ensure the expected values match with what's provided, even if no value is expected this is good for parity sake

Result
* We validate the access token provided + stored by `VerifyAccount` by calling the `ValidateSession` service
* All services have input validation coverage