### PR TITLE
rm yalc, bump ver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.7.2] - 2022-06-03
+### Modification
+- Modify due to build issue, republish at a bumped version
 
 ## [1.7.1] - 2022-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## [1.7.3] - 2022-06-03
+### Modification
+- Remove .yalc package reference from dependencies
+
 ## [1.7.2] - 2022-06-03
 ### Modification
 - Modify due to build issue, republish at a bumped version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xqmsg/jssdk-core",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A Javascript Implementation of XQ Message SDK, V.2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -67,7 +67,6 @@
     "webpack-cli": "^4.2.0"
   },
   "dependencies": {
-    "@xqmsg/jssdk-core": "file:.yalc/@xqmsg/jssdk-core",
     "buffer": "^6.0.3",
     "crypto-js": "3.1.9-1",
     "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xqmsg/jssdk-core",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A Javascript Implementation of XQ Message SDK, V.2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Problem/Solution
Due to an accidental build issue by including a `yalc` reference, we need to bump the minor version of our package's semantic version after removing this reference.