### PR TITLE
DEV-924: Added streaming encryption/decryption for large files to prevent memory crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xqmsg/jssdk-core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A Javascript Implementation of XQ Message SDK, V.2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "buffer": "^6.0.3",
-    "crypto-js": "3.1.9-1",
+    "crypto-js": "4.2.0",
     "jwt-decode": "^3.1.2",
     "memory-cache": "^0.2.0",
     "xhr2": "^0.2.1",

--- a/src/com/xqmsg/sdk/v2/algorithms/CTREncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/CTREncryption.ts
@@ -250,10 +250,10 @@ export default class CTREncryption extends EncryptionAlgorithm {
             function (
               success: boolean,
               filenameOrError: string,
-              rawContent?: Uint8Array
+              rawContent?: Blob
             ) {
               if (success && rawContent) {
-                const file = new File([Uint8Array.from(rawContent)], filenameOrError);
+                const file = new File([rawContent], filenameOrError);
                 return resolve(new ServerResponse(ServerResponse.OK, 200, file));
               } else {
                 return resolve(

--- a/src/com/xqmsg/sdk/v2/algorithms/CTREncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/CTREncryption.ts
@@ -150,13 +150,9 @@ export default class CTREncryption extends EncryptionAlgorithm {
             locatorKey,
             prefixedKey,
             file,
-            (success: boolean, rawContentOrError: Uint8Array|string) => {
+            (success: boolean, rawContentOrError: Blob|string) => {
                 if (success) {
-                  const rawContent = rawContentOrError as Uint8Array
-                  // Send the processed data to the user.
-                  const blob = new Blob([Uint8Array.from(rawContent)], {
-                    type: "application/octet-stream",
-                  });
+                  const blob = rawContentOrError as Blob
                   resolve(
                     new ServerResponse(
                       ServerResponse.OK,

--- a/src/com/xqmsg/sdk/v2/algorithms/CTREncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/CTREncryption.ts
@@ -144,18 +144,17 @@ export default class CTREncryption extends EncryptionAlgorithm {
         const self = this;
         self.sdk.validateAccessToken();
         const prefixedKey = `${this.filePrefix}${expandedKey}`;
-        return new Response(file).arrayBuffer().then((fileArrayBuffer) => {
-          return new Promise<ServerResponse>((resolve) => {
-            XQWebCrypto.auto.encryptFile(
-              file.name,
-              locatorKey,
-              prefixedKey,
-              new Uint8Array(fileArrayBuffer),
-              (success: boolean, rawContentOrError: Uint8Array|string) => {
+        return new Promise<ServerResponse>((resolve) => {
+          XQWebCrypto.auto.encryptFile(
+            file.name,
+            locatorKey,
+            prefixedKey,
+            file,
+            (success: boolean, rawContentOrError: Uint8Array|string) => {
                 if (success) {
                   const rawContent = rawContentOrError as Uint8Array
                   // Send the processed data to the user.
-                  const blob = new Blob([rawContent], {
+                  const blob = new Blob([Uint8Array.from(rawContent)], {
                     type: "application/octet-stream",
                   });
                   resolve(
@@ -180,7 +179,6 @@ export default class CTREncryption extends EncryptionAlgorithm {
               }
             );
           });
-        });
       } catch (exception) {
         return new Promise((resolve) => {
           resolve(
@@ -246,23 +244,30 @@ export default class CTREncryption extends EncryptionAlgorithm {
         const prefixedKey = await locateFn(locator).then((key) => {
           return `${this.filePrefix}${key}`;
         });
-        const fileDataArrayBuffer = await new Response(
-          sourceFile
-        ).arrayBuffer();
 
         return new Promise<ServerResponse>((resolve) => {
-          XQWebCrypto.auto.decryptFile(
-            fileDataArrayBuffer,
+          XQWebCrypto.ctr.decryptFile(
+            sourceFile,
             function (token: string, onFetched: (key: string) => void) {
               onFetched(prefixedKey);
             },
             function (
-              status: string,
-              filename: string,
-              rawContent: Uint8Array
+              success: boolean,
+              filenameOrError: string,
+              rawContent?: Uint8Array
             ) {
-              const file = new File([Uint8Array.from(rawContent)], filename);
-              return resolve(new ServerResponse(ServerResponse.OK, 200, file));
+              if (success && rawContent) {
+                const file = new File([Uint8Array.from(rawContent)], filenameOrError);
+                return resolve(new ServerResponse(ServerResponse.OK, 200, file));
+              } else {
+                return resolve(
+                  new ServerResponse(
+                    ServerResponse.ERROR,
+                    500,
+                    `Failed to decrypt file: ${filenameOrError}`
+                  )
+                );
+              }
             }
           );
         });
@@ -274,9 +279,9 @@ export default class CTREncryption extends EncryptionAlgorithm {
     };
     
     this.parseFileForDecrypt = async (file) => {
-      // Fetch the length of the token and the actual token. Wrapping in the "Response"
-      // class because Safari does not support Blob.arrayBuffer
-      const fileDataBytes = await new Response(file).arrayBuffer();
+      // Only read the header portion of the file instead of loading the entire file into memory
+      const headerSlice = file.slice(0, 1024);
+      const fileDataBytes = await new Response(headerSlice).arrayBuffer();
 
       let start = 0;
       let end = 4;

--- a/src/com/xqmsg/sdk/v2/algorithms/GCMEncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/GCMEncryption.ts
@@ -144,15 +144,20 @@ export default class GCMEncryption extends EncryptionAlgorithm {
         const self = this;
         self.sdk.validateAccessToken();
         const prefixedKey = `${this.filePrefix}${expandedKey}`;
-        return new Promise<ServerResponse>((resolve) => {
-          XQWebCrypto.auto.encryptFile(
-            file.name,
-            locatorKey,
-            prefixedKey,
-            file,
-            (success: boolean, rawContentOrError: Blob|string) => {
+        return new Response(file).arrayBuffer().then((fileArrayBuffer) => {
+          return new Promise<ServerResponse>((resolve) => {
+            XQWebCrypto.auto.encryptFile(
+              file.name,
+              locatorKey,
+              prefixedKey,
+              new Uint8Array(fileArrayBuffer),
+              (success: boolean, rawContentOrError: Uint8Array|string) => {
                 if (success) {
-                  const blob = rawContentOrError as Blob
+                  const rawContent = rawContentOrError as Uint8Array
+                  // Send the processed data to the user.
+                  const blob = new Blob([rawContent], {
+                    type: "application/octet-stream",
+                  });
                   resolve(
                     new ServerResponse(
                       ServerResponse.OK,
@@ -175,6 +180,7 @@ export default class GCMEncryption extends EncryptionAlgorithm {
               }
             );
           });
+        });
       } catch (exception) {
         return new Promise((resolve) => {
           resolve(
@@ -240,30 +246,23 @@ export default class GCMEncryption extends EncryptionAlgorithm {
         const prefixedKey = await locateFn(locator).then((key) => {
           return `${this.filePrefix}${key}`;
         });
+        const fileDataArrayBuffer = await new Response(
+          sourceFile
+        ).arrayBuffer();
 
         return new Promise<ServerResponse>((resolve) => {
-          XQWebCrypto.gcm.decryptFile(
-            sourceFile,
+          XQWebCrypto.auto.decryptFile(
+            fileDataArrayBuffer,
             function (token: string, onFetched: (key: string) => void) {
               onFetched(prefixedKey);
             },
             function (
-              success: boolean,
-              filenameOrError: string,
-              rawContent?: Blob
+              status: string,
+              filename: string,
+              rawContent: Uint8Array
             ) {
-              if (success && rawContent) {
-                const file = new File([rawContent], filenameOrError);
-                return resolve(new ServerResponse(ServerResponse.OK, 200, file));
-              } else {
-                return resolve(
-                  new ServerResponse(
-                    ServerResponse.ERROR,
-                    500,
-                    `Failed to decrypt file: ${filenameOrError}`
-                  )
-                );
-              }
+              const file = new File([Uint8Array.from(rawContent)], filename);
+              return resolve(new ServerResponse(ServerResponse.OK, 200, file));
             }
           );
         });
@@ -275,9 +274,9 @@ export default class GCMEncryption extends EncryptionAlgorithm {
     };
     
     this.parseFileForDecrypt = async (file) => {
-      // Only read the header portion of the file instead of loading the entire file into memory
-      const headerSlice = file.slice(0, 1024);
-      const fileDataBytes = await new Response(headerSlice).arrayBuffer();
+      // Fetch the length of the token and the actual token. Wrapping in the "Response"
+      // class because Safari does not support Blob.arrayBuffer
+      const fileDataBytes = await new Response(file).arrayBuffer();
 
       let start = 0;
       let end = 4;
@@ -303,10 +302,12 @@ export default class GCMEncryption extends EncryptionAlgorithm {
       start = end;
       end = start + fileNameSize - 1;
       const nameEncrypted = new Uint8Array(fileDataBytes.slice(start, end));
+      start = end;
+      const contentEncrypted = fileDataBytes.slice(start);
       return {
         locator,
         nameEncrypted,
-        contentEncrypted: new ArrayBuffer(0),
+        contentEncrypted,
       };
     };
   }

--- a/src/com/xqmsg/sdk/v2/algorithms/GCMEncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/GCMEncryption.ts
@@ -144,18 +144,17 @@ export default class GCMEncryption extends EncryptionAlgorithm {
         const self = this;
         self.sdk.validateAccessToken();
         const prefixedKey = `${this.filePrefix}${expandedKey}`;
-        return new Response(file).arrayBuffer().then((fileArrayBuffer) => {
-          return new Promise<ServerResponse>((resolve) => {
-            XQWebCrypto.auto.encryptFile(
-              file.name,
-              locatorKey,
-              prefixedKey,
-              new Uint8Array(fileArrayBuffer),
-              (success: boolean, rawContentOrError: Uint8Array|string) => {
+        return new Promise<ServerResponse>((resolve) => {
+          XQWebCrypto.auto.encryptFile(
+            file.name,
+            locatorKey,
+            prefixedKey,
+            file,
+            (success: boolean, rawContentOrError: Uint8Array|string) => {
                 if (success) {
                   const rawContent = rawContentOrError as Uint8Array
                   // Send the processed data to the user.
-                  const blob = new Blob([rawContent], {
+                  const blob = new Blob([Uint8Array.from(rawContent)], {
                     type: "application/octet-stream",
                   });
                   resolve(
@@ -180,7 +179,6 @@ export default class GCMEncryption extends EncryptionAlgorithm {
               }
             );
           });
-        });
       } catch (exception) {
         return new Promise((resolve) => {
           resolve(
@@ -246,23 +244,30 @@ export default class GCMEncryption extends EncryptionAlgorithm {
         const prefixedKey = await locateFn(locator).then((key) => {
           return `${this.filePrefix}${key}`;
         });
-        const fileDataArrayBuffer = await new Response(
-          sourceFile
-        ).arrayBuffer();
 
         return new Promise<ServerResponse>((resolve) => {
-          XQWebCrypto.auto.decryptFile(
-            fileDataArrayBuffer,
+          XQWebCrypto.gcm.decryptFile(
+            sourceFile,
             function (token: string, onFetched: (key: string) => void) {
               onFetched(prefixedKey);
             },
             function (
-              status: string,
-              filename: string,
-              rawContent: Uint8Array
+              success: boolean,
+              filenameOrError: string,
+              rawContent?: Uint8Array
             ) {
-              const file = new File([Uint8Array.from(rawContent)], filename);
-              return resolve(new ServerResponse(ServerResponse.OK, 200, file));
+              if (success && rawContent) {
+                const file = new File([Uint8Array.from(rawContent)], filenameOrError);
+                return resolve(new ServerResponse(ServerResponse.OK, 200, file));
+              } else {
+                return resolve(
+                  new ServerResponse(
+                    ServerResponse.ERROR,
+                    500,
+                    `Failed to decrypt file: ${filenameOrError}`
+                  )
+                );
+              }
             }
           );
         });
@@ -274,9 +279,9 @@ export default class GCMEncryption extends EncryptionAlgorithm {
     };
     
     this.parseFileForDecrypt = async (file) => {
-      // Fetch the length of the token and the actual token. Wrapping in the "Response"
-      // class because Safari does not support Blob.arrayBuffer
-      const fileDataBytes = await new Response(file).arrayBuffer();
+      // Only read the header portion of the file instead of loading the entire file into memory
+      const headerSlice = file.slice(0, 1024);
+      const fileDataBytes = await new Response(headerSlice).arrayBuffer();
 
       let start = 0;
       let end = 4;
@@ -302,12 +307,10 @@ export default class GCMEncryption extends EncryptionAlgorithm {
       start = end;
       end = start + fileNameSize - 1;
       const nameEncrypted = new Uint8Array(fileDataBytes.slice(start, end));
-      start = end;
-      const contentEncrypted = fileDataBytes.slice(start);
       return {
         locator,
         nameEncrypted,
-        contentEncrypted,
+        contentEncrypted: new ArrayBuffer(0),
       };
     };
   }

--- a/src/com/xqmsg/sdk/v2/algorithms/GCMEncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/GCMEncryption.ts
@@ -250,10 +250,10 @@ export default class GCMEncryption extends EncryptionAlgorithm {
             function (
               success: boolean,
               filenameOrError: string,
-              rawContent?: Uint8Array
+              rawContent?: Blob
             ) {
               if (success && rawContent) {
-                const file = new File([Uint8Array.from(rawContent)], filenameOrError);
+                const file = new File([rawContent], filenameOrError);
                 return resolve(new ServerResponse(ServerResponse.OK, 200, file));
               } else {
                 return resolve(

--- a/src/com/xqmsg/sdk/v2/algorithms/GCMEncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/GCMEncryption.ts
@@ -150,13 +150,9 @@ export default class GCMEncryption extends EncryptionAlgorithm {
             locatorKey,
             prefixedKey,
             file,
-            (success: boolean, rawContentOrError: Uint8Array|string) => {
+            (success: boolean, rawContentOrError: Blob|string) => {
                 if (success) {
-                  const rawContent = rawContentOrError as Uint8Array
-                  // Send the processed data to the user.
-                  const blob = new Blob([Uint8Array.from(rawContent)], {
-                    type: "application/octet-stream",
-                  });
+                  const blob = rawContentOrError as Blob
                   resolve(
                     new ServerResponse(
                       ServerResponse.OK,

--- a/src/com/xqmsg/sdk/v2/algorithms/OTPEncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/OTPEncryption.ts
@@ -243,10 +243,10 @@ export default class OTPEncryption extends EncryptionAlgorithm {
             function (
               success: boolean,
               filenameOrError: string,
-              rawContent?: Uint8Array
+              rawContent?: Blob
             ) {
               if (success && rawContent) {
-                const file = new File([Uint8Array.from(rawContent)], filenameOrError);
+                const file = new File([rawContent], filenameOrError);
                 return resolve(new ServerResponse(ServerResponse.OK, 200, file));
               } else {
                 return resolve(

--- a/src/com/xqmsg/sdk/v2/algorithms/OTPEncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/OTPEncryption.ts
@@ -150,7 +150,7 @@ export default class OTPEncryption extends EncryptionAlgorithm {
                 if (success) {
                   const rawContent = rawContentOrError as Uint8Array
                   // Send the processed data to the user.
-                  const blob = new Blob([rawContent], {
+                  const blob = new Blob([Uint8Array.from(rawContent)], {
                     type: "application/octet-stream",
                   });
                   resolve(
@@ -239,18 +239,28 @@ export default class OTPEncryption extends EncryptionAlgorithm {
         });
 
         return new Promise<ServerResponse>((resolve) => {
-          XQWebCrypto.auto.decryptFile(
+          XQWebCrypto.otp.decryptFile(
             sourceFile,
             function (token: string, onFetched: (key: string) => void) {
               onFetched(prefixedKey);
             },
             function (
-              status: string,
-              filename: string,
-              rawContent: Uint8Array
+              success: boolean,
+              filenameOrError: string,
+              rawContent?: Uint8Array
             ) {
-              const file = new File([Uint8Array.from(rawContent)], filename);
-              return resolve(new ServerResponse(ServerResponse.OK, 200, file));
+              if (success && rawContent) {
+                const file = new File([Uint8Array.from(rawContent)], filenameOrError);
+                return resolve(new ServerResponse(ServerResponse.OK, 200, file));
+              } else {
+                return resolve(
+                  new ServerResponse(
+                    ServerResponse.ERROR,
+                    500,
+                    `Failed to decrypt file: ${filenameOrError}`
+                  )
+                );
+              }
             }
           );
         });
@@ -295,7 +305,7 @@ export default class OTPEncryption extends EncryptionAlgorithm {
       return {
         locator,
         nameEncrypted,
-        contentEncrypted,
+        contentEncrypted: new ArrayBuffer(0), // Empty placeholder for type compatibility
       };
     };
   }

--- a/src/com/xqmsg/sdk/v2/algorithms/OTPEncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/OTPEncryption.ts
@@ -237,13 +237,10 @@ export default class OTPEncryption extends EncryptionAlgorithm {
         const prefixedKey = await locateFn(locator).then((key) => {
           return `${this.filePrefix}${key}`;
         });
-        const fileDataArrayBuffer = await new Response(
-          sourceFile
-        ).arrayBuffer();
 
         return new Promise<ServerResponse>((resolve) => {
           XQWebCrypto.auto.decryptFile(
-            fileDataArrayBuffer,
+            sourceFile,
             function (token: string, onFetched: (key: string) => void) {
               onFetched(prefixedKey);
             },
@@ -265,13 +262,13 @@ export default class OTPEncryption extends EncryptionAlgorithm {
     };
 
     this.parseFileForDecrypt = async (file) => {
-      // Fetch the length of the token and the actual token. Wrapping in the "Response"
-      // class because Safari does not support Blob.arrayBuffer
-      const fileDataBytes = await new Response(file).arrayBuffer();
+      // Only read the header portion
+      const headerSlice = file.slice(0, 1024);
+      const headerBytes = await new Response(headerSlice).arrayBuffer();
 
       let start = 0;
       let end = 4;
-      const locatorSize = new Uint32Array(fileDataBytes.slice(start, end))[0];
+      const locatorSize = new Uint32Array(headerBytes.slice(start, end))[0];
       if (locatorSize > 256) {
         throw new Error(
           "Unable to parse file, check that the file is valid and not damaged"
@@ -280,11 +277,11 @@ export default class OTPEncryption extends EncryptionAlgorithm {
       start = end;
       end = start + locatorSize - 1;
       const locator = new TextDecoder().decode(
-        new Uint8Array(fileDataBytes.slice(start, end))
+        new Uint8Array(headerBytes.slice(start, end))
       );
       start = end;
       end = start + 4;
-      const fileNameSize = new Uint32Array(fileDataBytes.slice(start, end))[0];
+      const fileNameSize = new Uint32Array(headerBytes.slice(start, end))[0];
       if (fileNameSize < 2 || fileNameSize > 2000) {
         throw new Error(
           "Unable to parse file, check that the file is valid and not damaged"
@@ -292,9 +289,9 @@ export default class OTPEncryption extends EncryptionAlgorithm {
       }
       start = end;
       end = start + fileNameSize - 1;
-      const nameEncrypted = new Uint8Array(fileDataBytes.slice(start, end));
+      const nameEncrypted = new Uint8Array(headerBytes.slice(start, end));
       start = end;
-      const contentEncrypted = fileDataBytes.slice(start);
+      const contentEncrypted = headerBytes.slice(start);
       return {
         locator,
         nameEncrypted,

--- a/src/com/xqmsg/sdk/v2/algorithms/OTPEncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/OTPEncryption.ts
@@ -146,13 +146,9 @@ export default class OTPEncryption extends EncryptionAlgorithm {
             locatorKey,
             prefixedKey,
             file,
-            (success: boolean, rawContentOrError: Uint8Array|string) => {
+            (success: boolean, rawContentOrError: Blob|string) => {
                 if (success) {
-                  const rawContent = rawContentOrError as Uint8Array
-                  // Send the processed data to the user.
-                  const blob = new Blob([Uint8Array.from(rawContent)], {
-                    type: "application/octet-stream",
-                  });
+                  const blob = rawContentOrError as Blob
                   resolve(
                     new ServerResponse(
                       ServerResponse.OK,

--- a/src/com/xqmsg/sdk/v2/algorithms/OTPEncryption.ts
+++ b/src/com/xqmsg/sdk/v2/algorithms/OTPEncryption.ts
@@ -140,14 +140,13 @@ export default class OTPEncryption extends EncryptionAlgorithm {
         const self = this;
         self.sdk.validateAccessToken();
         const prefixedKey = `${this.filePrefix}${expandedKey}`;
-        return new Response(file).arrayBuffer().then((fileArrayBuffer) => {
-          return new Promise<ServerResponse>((resolve) => {
-            XQWebCrypto.auto.encryptFile(
-              file.name,
-              locatorKey,
-              prefixedKey,
-              new Uint8Array(fileArrayBuffer),
-              (success: boolean, rawContentOrError: Uint8Array|string) => {
+        return new Promise<ServerResponse>((resolve) => {
+          XQWebCrypto.auto.encryptFile(
+            file.name,
+            locatorKey,
+            prefixedKey,
+            file,
+            (success: boolean, rawContentOrError: Uint8Array|string) => {
                 if (success) {
                   const rawContent = rawContentOrError as Uint8Array
                   // Send the processed data to the user.
@@ -176,7 +175,6 @@ export default class OTPEncryption extends EncryptionAlgorithm {
               }
             );
           });
-        });
       } catch (exception) {
         return new Promise((resolve) => {
           resolve(

--- a/src/com/xqmsg/sdk/v2/services/CodeValidator.ts
+++ b/src/com/xqmsg/sdk/v2/services/CodeValidator.ts
@@ -26,10 +26,11 @@ export default class CodeValidator extends XQModule {
   /**
    * @param {Map} maybePayload - the container for the request parameters supplied to this method.
    * @param {String} maybePayload.pin - the two-factor pin used to validate the `Authorize` service request
+   * @param {number} [maybePayload.teamId] - the team ID to exchange the pre-auth token for
    *
    * @returns {Promise<ServerResponse<{payload:String}>>} a `ServerResponse` containing the access token
    */
-  supplyAsync: (maybePayload: { pin: string }) => Promise<ServerResponse>;
+  supplyAsync: (maybePayload: { pin: string; teamId?: number }) => Promise<ServerResponse>;
 
   constructor(sdk: XQSDK) {
     super(sdk);
@@ -47,19 +48,21 @@ export default class CodeValidator extends XQModule {
           Authorization: "Bearer " + preAuthToken,
         };
 
+        const codeValidationPayload = { [CodeValidator.PIN]: maybePayload.pin };
+
         return this.sdk
           .call(
             this.sdk.SUBSCRIPTION_SERVER_URL,
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayload,
+            codeValidationPayload,
             true
           )
           .then((response: ServerResponse) => {
             switch (response.status) {
               case ServerResponse.OK: {
-                return new ExchangeForAccessToken(self.sdk).supplyAsync(null);
+                return new ExchangeForAccessToken(self.sdk).supplyAsync(maybePayload.teamId);
               }
               case ServerResponse.ERROR: {
                 return handleException(response, XQServices.CodeValidator);

--- a/src/com/xqmsg/sdk/v2/services/ExchangeForAccessToken.ts
+++ b/src/com/xqmsg/sdk/v2/services/ExchangeForAccessToken.ts
@@ -18,18 +18,18 @@ export default class ExchangeForAccessToken extends XQModule {
   serviceName: string;
   requiredFields: string[];
   /**
-   * @param {Map} [maybePayload=null] - Container for the request parameters supplied to this method.
+   * @param {number} [teamId] - The specific Team ID to exchange the pre-auth token for authorization
    *
    * @returns {Promise<ServerResponse<{payload:String}>>}
    */
-  supplyAsync: (maybePayload:null) => Promise<ServerResponse>;
+  supplyAsync: (teamId?: number) => Promise<ServerResponse>;
 
   constructor(sdk: XQSDK) {
     super(sdk);
     this.serviceName = "exchange";
     this.requiredFields = [];
 
-    this.supplyAsync = (maybePayload) => {
+    this.supplyAsync = (teamId) => {
       try {
         this.sdk.validateInput({}, this.requiredFields);
 
@@ -41,13 +41,15 @@ export default class ExchangeForAccessToken extends XQModule {
           Authorization: "Bearer " + preAuthToken,
         };
 
+        const payload = teamId !== undefined ? { b: teamId.toString() } : null;
+        
         return this.sdk
           .call(
             this.sdk.SUBSCRIPTION_SERVER_URL,
             this.serviceName,
             CallMethod.GET,
             additionalHeaderProperties,
-            maybePayload,
+            payload,
             true
           )
           .then((response: ServerResponse) => {

--- a/src/com/xqmsg/web-crypto/webcrypto.js
+++ b/src/com/xqmsg/web-crypto/webcrypto.js
@@ -517,7 +517,6 @@ export const XQWebCrypto = {
         
         encryptFileStreaming: async function (file, password, header) {
             const chunkSize = 1024 * 1024;
-            const reader = file.stream().getReader();
             const encryptedChunks = [];
             const batchedBlobs = [];
             const batchSize = 1000;
@@ -536,12 +535,18 @@ export const XQWebCrypto = {
             const derivedKey = await XQWebCrypto._pbkdf2(password, bodySalt, this.iterations, this.keyLength, this.hash);
             const cryptoKey = await window.crypto.subtle.importKey('raw', derivedKey, { name: this.algorithm }, false, ['encrypt']);
 
-            while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
+            const fileSize = file.size;
+            let offset = 0;
+
+            while (offset < fileSize) {
+                const end = Math.min(offset + chunkSize, fileSize);
+                const chunk = file.slice(offset, end);
+                const arrayBuffer = await new Response(chunk).arrayBuffer();
+                const value = new Uint8Array(arrayBuffer);
 
                 const encryptedChunk = await this.encryptChunk(value, cryptoKey);
                 encryptedChunks.push(encryptedChunk);
+                offset = end;
                 
                 // Batch: create intermediate Blob when we hit batchSize
                 if (encryptedChunks.length >= batchSize) {
@@ -1084,7 +1089,7 @@ export const XQWebCrypto = {
         },
         
         encryptFileStreaming: async function (file, password, header) {
-            const reader = file.stream().getReader();
+            const chunkSize = 1024 * 1024;
             const encryptedChunks = [];
             const batchedBlobs = [];
             const batchSize = 1000;
@@ -1093,13 +1098,20 @@ export const XQWebCrypto = {
             // Add header to the first batch
             batchedBlobs.push(new Blob([header], { type: 'application/octet-stream' }));
 
-            while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
+            const fileSize = file.size;
+            let offset = 0;
+
+            while (offset < fileSize) {
+                const end = Math.min(offset + chunkSize, fileSize);
+                const chunk = file.slice(offset, end);
+                const arrayBuffer = await new Response(chunk).arrayBuffer();
+                const value = new Uint8Array(arrayBuffer);
+
                 const encryptedChunk = await this.encryptChunk(value, password, keyOffset);
                 encryptedChunks.push(encryptedChunk);
                 
-                keyOffset = (keyOffset + value.length) % (password.length - 2); // -2 for prefix
+                keyOffset = (keyOffset + value.length) % (password.length - 2);
+                offset = end;
                 
                 // Batch: create intermediate Blob when we hit batchSize
                 if (encryptedChunks.length >= batchSize) {

--- a/src/com/xqmsg/web-crypto/webcrypto.js
+++ b/src/com/xqmsg/web-crypto/webcrypto.js
@@ -520,16 +520,8 @@ export const XQWebCrypto = {
             }
             encryptedChunks.splice(1, 0, chunkMetadata);
 
-            const totalLength = encryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
-            const finalResult = new Uint8Array(totalLength);
-            let offset = 0;
-            
-            for (const chunk of encryptedChunks) {
-                finalResult.set(chunk, offset);
-                offset += chunk.length;
-            }
-
-            return finalResult;
+            // Return a Blob instead of Uint8Array to avoid 2GB limit
+            return new Blob(encryptedChunks, { type: 'application/octet-stream' });
         },
 
         encryptChunk: async function (chunk, cryptoKey) {
@@ -663,16 +655,8 @@ export const XQWebCrypto = {
                 encryptedChunks.push(encryptedChunk);
             }
 
-            const totalLength = encryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
-            const finalResult = new Uint8Array(totalLength);
-            let offset = 0;
-            
-            for (const chunk of encryptedChunks) {
-                finalResult.set(chunk, offset);
-                offset += chunk.length;
-            }
-
-            return finalResult;
+            // Return a Blob instead of Uint8Array to avoid 2GB limit
+            return new Blob(encryptedChunks, { type: 'application/octet-stream' });
         },
 
         encryptChunk: async function (chunk, cryptoKey) {
@@ -1201,16 +1185,8 @@ export const XQWebCrypto = {
                 keyOffset = (keyOffset + value.length) % (password.length - 2); // -2 for prefix
             }
 
-            const totalLength = encryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
-            const finalResult = new Uint8Array(totalLength);
-            let offset = 0;
-            
-            for (const chunk of encryptedChunks) {
-                finalResult.set(chunk, offset);
-                offset += chunk.length;
-            }
-
-            return finalResult;
+            // Return a Blob instead of Uint8Array to avoid 2GB limit
+            return new Blob(encryptedChunks, { type: 'application/octet-stream' });
         },
 
         encryptChunk: async function (chunk, password, keyOffset) {

--- a/src/com/xqmsg/web-crypto/webcrypto.js
+++ b/src/com/xqmsg/web-crypto/webcrypto.js
@@ -327,20 +327,25 @@ export const XQWebCrypto = {
 
             const header = await XQWebCrypto.createFileHeader(encodedFilename, token, algo);
             
-            // only use streaming for OTP algorithm for now
-            if (algo.algorithm !== 'OTP') {
+            // Use streaming for OTP, GCM, and CTR algorithms
+            if (algo.algorithm === 'OTP') {
+                const result = await XQWebCrypto.otp.encryptFileStreaming(file, password, header);
+                onComplete(true, result);
+            } else if (algo.algorithm === 'AES-GCM') {
+                const result = await XQWebCrypto.gcm.encryptFileStreaming(file, password, header);
+                onComplete(true, result);
+            } else if (algo.algorithm === 'AES-CTR') {
+                const result = await XQWebCrypto.ctr.encryptFileStreaming(file, password, header);
+                onComplete(true, result);
+            } else {
+                // Fallback to non-streaming for other algorithms
                 const fileArrayBuffer = await new Response(file).arrayBuffer();
                 algo.encrypt(new Uint8Array(fileArrayBuffer), password, true, header).then(function (encrypted) {
                     onComplete(true, encrypted);
                 }).catch(function (err) {
                     onComplete(false, err.message ?? err);
                 });
-                return;
             }
-
-            // streaming encryption for OTP
-            const result = await XQWebCrypto.otp.encryptFileStreaming(file, password, header);
-            onComplete(true, result);
 
         } catch (err) {
             onComplete(false, err.message ?? err);
@@ -396,9 +401,18 @@ export const XQWebCrypto = {
                         }
                     }
 
-                    // Only use streaming for OTP algorithm for now
-                    if (algo.algorithm !== 'OTP') {
-
+                    // Use streaming for OTP, GCM, and CTR algorithms
+                    if (algo.algorithm === 'OTP') {
+                        const result = await XQWebCrypto.otp.decryptFileStreaming(file, password, header);
+                        onComplete(true, header.filename, result);
+                    } else if (algo.algorithm === 'AES-GCM') {
+                        const result = await XQWebCrypto.gcm.decryptFileStreaming(file, password, header);
+                        onComplete(true, header.filename, result);
+                    } else if (algo.algorithm === 'AES-CTR') {
+                        const result = await XQWebCrypto.ctr.decryptFileStreaming(file, password, header);
+                        onComplete(true, header.filename, result);
+                    } else {
+                        // Fallback to non-streaming for other algorithms
                         const fileArrayBuffer = await new Response(file).arrayBuffer();
                         const data = new Uint8Array(fileArrayBuffer);
                         const buf = data.slice(header.length);
@@ -408,11 +422,7 @@ export const XQWebCrypto = {
                         }).catch(function (err) {
                             onComplete(false, err.message ?? err);
                         });
-                        return;
                     }
-
-                    const result = await XQWebCrypto.otp.decryptFileStreaming(file, password, header);
-                    onComplete(true, header.filename, result);
 
                 } catch (err) {
                     onComplete(false, err.message ?? err);
@@ -477,6 +487,134 @@ export const XQWebCrypto = {
                     onComplete(false, err.message ?? err)
                 });
 
+        },
+        
+        encryptFileStreaming: async function (file, password, header) {
+            const chunkSize = 1024 * 1024;
+            const reader = file.stream().getReader();
+            const encryptedChunks = [];
+            const chunkLengths = [];
+
+            encryptedChunks.push(header);
+            
+            // Derive the key once using PBKDF2
+            if (password[0] === '.') password = password.slice(2);
+            const salt = header.slice(header.length - this.saltLength, header.length);
+            const derivedKey = await XQWebCrypto._pbkdf2(password, salt, this.iterations, this.keyLength, this.hash);
+            const cryptoKey = await window.crypto.subtle.importKey('raw', derivedKey, { name: this.algorithm }, false, ['encrypt']);
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+
+                const encryptedChunk = await this.encryptChunk(value, cryptoKey);
+                chunkLengths.push(encryptedChunk.length);
+                encryptedChunks.push(encryptedChunk);
+            }
+
+            const chunkMetadata = new Uint8Array(4 + (chunkLengths.length * 4));
+            const metadataView = new DataView(chunkMetadata.buffer);
+            metadataView.setUint32(0, chunkLengths.length, true);
+            for (let i = 0; i < chunkLengths.length; i++) {
+                metadataView.setUint32(4 + (i * 4), chunkLengths[i], true);
+            }
+            encryptedChunks.splice(1, 0, chunkMetadata);
+
+            const totalLength = encryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+            const finalResult = new Uint8Array(totalLength);
+            let offset = 0;
+            
+            for (const chunk of encryptedChunks) {
+                finalResult.set(chunk, offset);
+                offset += chunk.length;
+            }
+
+            return finalResult;
+        },
+
+        encryptChunk: async function (chunk, cryptoKey) {
+            const iv = window.crypto.getRandomValues(new Uint8Array(this.ivLength));
+            const encrypted = await window.crypto.subtle.encrypt(
+                { name: this.algorithm, iv: iv },
+                cryptoKey,
+                chunk
+            );
+            
+            const result = new Uint8Array(iv.length + encrypted.byteLength);
+            result.set(iv, 0);
+            result.set(new Uint8Array(encrypted), iv.length);
+            
+            return result;
+        },
+
+        decryptFileStreaming: async function (file, password, header) {
+            const contentStart = header.length;
+            
+            // Derive the key once using PBKDF2
+            if (password[0] === '.') password = password.slice(2);
+            // Extract salt from the header
+            const headerSlice = file.slice(0, contentStart);
+            const headerBytes = await new Response(headerSlice).arrayBuffer();
+            const headerData = new Uint8Array(headerBytes);
+            const salt = headerData.slice(headerData.length - this.saltLength, headerData.length);
+            
+            const derivedKey = await XQWebCrypto._pbkdf2(password, salt, this.iterations, this.keyLength, this.hash);
+            const cryptoKey = await window.crypto.subtle.importKey('raw', derivedKey, { name: this.algorithm }, false, ['decrypt']);
+            
+            const metadataSlice = file.slice(contentStart, contentStart + 4);
+            const metadataBytes = await new Response(metadataSlice).arrayBuffer();
+            const metadataView = new DataView(metadataBytes);
+            const chunkCount = metadataView.getUint32(0, true);
+
+            const lengthsSlice = file.slice(contentStart + 4, contentStart + 4 + (chunkCount * 4));
+            const lengthsBytes = await new Response(lengthsSlice).arrayBuffer();
+            const lengthsView = new DataView(lengthsBytes);
+            const chunkLengths = [];
+            for (let i = 0; i < chunkCount; i++) {
+                chunkLengths.push(lengthsView.getUint32(i * 4, true));
+            }
+
+            const decryptedChunks = [];
+            let currentPosition = contentStart + 4 + (chunkCount * 4);
+            
+            for (const chunkLength of chunkLengths) {
+                const chunkSlice = file.slice(currentPosition, currentPosition + chunkLength);
+                const chunkBytes = await new Response(chunkSlice).arrayBuffer();
+                const chunkData = new Uint8Array(chunkBytes);
+                
+                try {
+                    const decryptedChunk = await this.decryptChunk(chunkData, cryptoKey);
+                    decryptedChunks.push(decryptedChunk);
+                    currentPosition += chunkLength;
+                } catch (error) {
+                    throw new Error(`Authentication failed at chunk: ${error.message}`);
+                }
+            }
+            
+            // Combine all decrypted chunks
+            const totalLength = decryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+            const finalResult = new Uint8Array(totalLength);
+            let offset = 0;
+            
+            for (const chunk of decryptedChunks) {
+                finalResult.set(chunk, offset);
+                offset += chunk.length;
+            }
+            
+            return finalResult;
+        },
+
+        decryptChunk: async function (chunk, cryptoKey) {
+            const iv = chunk.slice(0, this.ivLength);
+            const encryptedData = chunk.slice(this.ivLength);
+            
+            const decrypted = await window.crypto.subtle.decrypt(
+                { name: this.algorithm, iv: iv },
+                cryptoKey,
+                encryptedData
+            );
+            
+            return new Uint8Array(decrypted);
         }
     },
     // Counter mode encrpytion.
@@ -503,6 +641,124 @@ export const XQWebCrypto = {
         },
         decryptFile: async function (byteContent, onFetchPassword, onComplete) {
             return XQWebCrypto._decryptFile(this, byteContent, onFetchPassword, onComplete);
+        },
+        
+        encryptFileStreaming: async function (file, password, header) {
+            const chunkSize = 1024 * 1024;
+            const reader = file.stream().getReader();
+            const encryptedChunks = [];
+            encryptedChunks.push(header);
+            
+            // Derive the key once using PBKDF2
+            if (password[0] === '.') password = password.slice(2);
+            const salt = header.slice(header.length - this.saltLength, header.length);
+            const derivedKey = await XQWebCrypto._pbkdf2(password, salt, this.iterations, this.keyLength, this.hash);
+            const cryptoKey = await window.crypto.subtle.importKey('raw', derivedKey, { name: this.algorithm }, false, ['encrypt']);
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+
+                const encryptedChunk = await this.encryptChunk(value, cryptoKey);
+                encryptedChunks.push(encryptedChunk);
+            }
+
+            const totalLength = encryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+            const finalResult = new Uint8Array(totalLength);
+            let offset = 0;
+            
+            for (const chunk of encryptedChunks) {
+                finalResult.set(chunk, offset);
+                offset += chunk.length;
+            }
+
+            return finalResult;
+        },
+
+        encryptChunk: async function (chunk, cryptoKey) {
+            const counter = window.crypto.getRandomValues(new Uint8Array(this.ivLength));
+            counter.fill(0, 8);
+            
+            const encrypted = await window.crypto.subtle.encrypt(
+                { name: this.algorithm, counter: counter, length: 64 },
+                cryptoKey,
+                chunk
+            );
+            
+            window.crypto.getRandomValues(counter.subarray(8, 16));
+
+            const result = new Uint8Array(counter.length + encrypted.byteLength);
+            result.set(counter, 0);
+            result.set(new Uint8Array(encrypted), counter.length);
+            
+            return result;
+        },
+
+        decryptFileStreaming: async function (file, password, header) {
+            const chunkSize = 1024 * 1024;
+            const fileSize = file.size;
+            const contentStart = header.length;
+            
+            // Derive the key once using PBKDF2
+            if (password[0] === '.') password = password.slice(2);
+            const headerSlice = file.slice(0, contentStart);
+            const headerBytes = await new Response(headerSlice).arrayBuffer();
+            const headerData = new Uint8Array(headerBytes);
+            const salt = headerData.slice(headerData.length - this.saltLength, headerData.length);
+            
+            const derivedKey = await XQWebCrypto._pbkdf2(password, salt, this.iterations, this.keyLength, this.hash);
+            const cryptoKey = await window.crypto.subtle.importKey('raw', derivedKey, { name: this.algorithm }, false, ['decrypt']);
+            
+            const decryptedChunks = [];
+            const actualContentStart = contentStart;
+            const actualContentEnd = fileSize;
+            
+            let currentPosition = actualContentStart;
+
+            while (currentPosition < actualContentEnd) {
+                const encryptedChunkSize = this.ivLength + chunkSize;
+                const chunkEnd = Math.min(currentPosition + encryptedChunkSize, actualContentEnd);
+                const chunkSlice = file.slice(currentPosition, chunkEnd);
+                const chunkBytes = await new Response(chunkSlice).arrayBuffer();
+                const chunkData = new Uint8Array(chunkBytes);
+
+                if (chunkData.length < this.ivLength + 1) {
+                    break;
+                }
+                
+                try {
+                    const decryptedChunk = await this.decryptChunk(chunkData, cryptoKey);
+                    decryptedChunks.push(decryptedChunk);
+                    currentPosition += chunkData.length;
+                } catch (error) {
+                    throw new Error(`Decryption failed at position ${currentPosition}: ${error.message}`);
+                }
+            }
+
+            const totalLength = decryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+            const finalResult = new Uint8Array(totalLength);
+            let offset = 0;
+            
+            for (const chunk of decryptedChunks) {
+                finalResult.set(chunk, offset);
+                offset += chunk.length;
+            }
+
+            return finalResult;
+        },
+
+        decryptChunk: async function (chunk, cryptoKey) {
+            const counter = chunk.slice(0, this.ivLength);
+            const encryptedData = chunk.slice(this.ivLength);
+            counter.fill(0, 8);
+            
+            const decrypted = await window.crypto.subtle.decrypt(
+                { name: this.algorithm, counter: counter, length: 64 },
+                cryptoKey,
+                encryptedData
+            );
+            
+            return new Uint8Array(decrypted);
         }
     },
 
@@ -905,7 +1161,7 @@ export const XQWebCrypto = {
             }
 
             if (raw) {
-                return j;
+                return new Uint8Array(j);
             }
 
             var encoded = new TextDecoder("utf8").decode(new Uint8Array(j));

--- a/src/com/xqmsg/web-crypto/webcrypto.js
+++ b/src/com/xqmsg/web-crypto/webcrypto.js
@@ -287,6 +287,11 @@ export const XQWebCrypto = {
     },
 
     _encryptFile: async function (algo, filename, byteContent, token, password, onComplete) {
+        
+        if (byteContent instanceof File) {
+            return XQWebCrypto._encryptFileStreaming(algo, filename, byteContent, token, password, onComplete);
+        }
+        
         filename = filename ? new TextEncoder().encode(filename) : null;
         if (filename) {
             try {
@@ -305,6 +310,41 @@ export const XQWebCrypto = {
         }).catch(function (err) {
             onComplete(false, err.message ?? err);
         });
+    },
+
+    _encryptFileStreaming: async function (algo, filename, file, token, password, onComplete) {
+        try {
+    
+            var encodedFilename = filename ? new TextEncoder().encode(filename) : null;
+            if (encodedFilename) {
+                try {
+                    encodedFilename = await algo.encrypt(encodedFilename, password, true, null);
+                } catch (err) {
+                    onComplete(false, err.message ?? err);
+                    return;
+                }
+            }
+
+            const header = await XQWebCrypto.createFileHeader(encodedFilename, token, algo);
+            
+            // only use streaming for OTP algorithm for now
+            if (algo.algorithm !== 'OTP') {
+                const fileArrayBuffer = await new Response(file).arrayBuffer();
+                algo.encrypt(new Uint8Array(fileArrayBuffer), password, true, header).then(function (encrypted) {
+                    onComplete(true, encrypted);
+                }).catch(function (err) {
+                    onComplete(false, err.message ?? err);
+                });
+                return;
+            }
+
+            // streaming encryption for OTP
+            const result = await XQWebCrypto.otp.encryptFileStreaming(file, password, header);
+            onComplete(true, result);
+
+        } catch (err) {
+            onComplete(false, err.message ?? err);
+        }
     },
 
     _decryptFile: async function (algo, byteContent, onFetchPassword, onComplete) {
@@ -832,6 +872,51 @@ export const XQWebCrypto = {
                 .catch(function (err) {
                     onComplete(false, err.message ?? err)
                 });
+        },
+        
+        encryptFileStreaming: async function (file, password, header) {
+            const chunkSize = 1024 * 1024;
+            const reader = file.stream().getReader();
+            const encryptedChunks = [];
+            let keyOffset = 0;
+            encryptedChunks.push(header);
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+
+                const encryptedChunk = await this.encryptChunk(value, password, keyOffset);
+                encryptedChunks.push(encryptedChunk);
+                
+                keyOffset = (keyOffset + value.length) % (password.length - 2); // -2 for prefix
+            }
+
+            const totalLength = encryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+            const finalResult = new Uint8Array(totalLength);
+            let offset = 0;
+            
+            for (const chunk of encryptedChunks) {
+                finalResult.set(chunk, offset);
+                offset += chunk.length;
+            }
+
+            return finalResult;
+        },
+
+        encryptChunk: async function (chunk, password, keyOffset) {
+            if (password[0] === '.') password = password.slice(2);
+            
+            var encoder = new TextEncoder("utf8");
+            var keyBytes = encoder.encode(password);
+            var payloadBytes = new Uint8Array(chunk);
+            var encrypted = new Uint8Array(payloadBytes.length);
+
+            for (var idx = 0; idx < payloadBytes.length; idx++) {
+                var keyIdx = (keyOffset + idx) % keyBytes.length;
+                encrypted[idx] = payloadBytes[idx] ^ keyBytes[keyIdx];
+            }
+
+            return encrypted;
         }
     },
     auto: {

--- a/src/com/xqmsg/web-crypto/webcrypto.js
+++ b/src/com/xqmsg/web-crypto/webcrypto.js
@@ -583,17 +583,8 @@ export const XQWebCrypto = {
                 }
             }
             
-            // Combine all decrypted chunks
-            const totalLength = decryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
-            const finalResult = new Uint8Array(totalLength);
-            let offset = 0;
-            
-            for (const chunk of decryptedChunks) {
-                finalResult.set(chunk, offset);
-                offset += chunk.length;
-            }
-            
-            return finalResult;
+            // Return a Blob instead of Uint8Array to avoid 2GB limit
+            return new Blob(decryptedChunks, { type: 'application/octet-stream' });
         },
 
         decryptChunk: async function (chunk, cryptoKey) {
@@ -719,16 +710,8 @@ export const XQWebCrypto = {
                 }
             }
 
-            const totalLength = decryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
-            const finalResult = new Uint8Array(totalLength);
-            let offset = 0;
-            
-            for (const chunk of decryptedChunks) {
-                finalResult.set(chunk, offset);
-                offset += chunk.length;
-            }
-
-            return finalResult;
+            // Return a Blob instead of Uint8Array to avoid 2GB limit
+            return new Blob(decryptedChunks, { type: 'application/octet-stream' });
         },
 
         decryptChunk: async function (chunk, cryptoKey) {
@@ -1229,14 +1212,8 @@ export const XQWebCrypto = {
 
             const totalLength = decryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
             const finalResult = new Uint8Array(totalLength);
-            let offset = 0;
-            
-            for (const chunk of decryptedChunks) {
-                finalResult.set(chunk, offset);
-                offset += chunk.length;
-            }
-
-            return finalResult;
+            // Return a Blob instead of Uint8Array to avoid 2GB limit
+            return new Blob(decryptedChunks, { type: 'application/octet-stream' });
         },
 
         decryptChunk: async function (chunk, password, keyOffset) {

--- a/src/com/xqmsg/web-crypto/webcrypto.js
+++ b/src/com/xqmsg/web-crypto/webcrypto.js
@@ -487,117 +487,6 @@ export const XQWebCrypto = {
                     onComplete(false, err.message ?? err)
                 });
 
-        },
-        
-        encryptFileStreaming: async function (file, password, header) {
-            const chunkSize = 1024 * 1024;
-            const reader = file.stream().getReader();
-            const encryptedChunks = [];
-            const chunkLengths = [];
-
-            encryptedChunks.push(header);
-            
-            // Derive the key once using PBKDF2
-            if (password[0] === '.') password = password.slice(2);
-            const salt = header.slice(header.length - this.saltLength, header.length);
-            const derivedKey = await XQWebCrypto._pbkdf2(password, salt, this.iterations, this.keyLength, this.hash);
-            const cryptoKey = await window.crypto.subtle.importKey('raw', derivedKey, { name: this.algorithm }, false, ['encrypt']);
-
-            while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
-
-                const encryptedChunk = await this.encryptChunk(value, cryptoKey);
-                chunkLengths.push(encryptedChunk.length);
-                encryptedChunks.push(encryptedChunk);
-            }
-
-            const chunkMetadata = new Uint8Array(4 + (chunkLengths.length * 4));
-            const metadataView = new DataView(chunkMetadata.buffer);
-            metadataView.setUint32(0, chunkLengths.length, true);
-            for (let i = 0; i < chunkLengths.length; i++) {
-                metadataView.setUint32(4 + (i * 4), chunkLengths[i], true);
-            }
-            encryptedChunks.splice(1, 0, chunkMetadata);
-
-            // Return a Blob instead of Uint8Array to avoid 2GB limit
-            return new Blob(encryptedChunks, { type: 'application/octet-stream' });
-        },
-
-        encryptChunk: async function (chunk, cryptoKey) {
-            const iv = window.crypto.getRandomValues(new Uint8Array(this.ivLength));
-            const encrypted = await window.crypto.subtle.encrypt(
-                { name: this.algorithm, iv: iv },
-                cryptoKey,
-                chunk
-            );
-            
-            const result = new Uint8Array(iv.length + encrypted.byteLength);
-            result.set(iv, 0);
-            result.set(new Uint8Array(encrypted), iv.length);
-            
-            return result;
-        },
-
-        decryptFileStreaming: async function (file, password, header) {
-            const contentStart = header.length;
-            
-            // Derive the key once using PBKDF2
-            if (password[0] === '.') password = password.slice(2);
-            // Extract salt from the header
-            const headerSlice = file.slice(0, contentStart);
-            const headerBytes = await new Response(headerSlice).arrayBuffer();
-            const headerData = new Uint8Array(headerBytes);
-            const salt = headerData.slice(headerData.length - this.saltLength, headerData.length);
-            
-            const derivedKey = await XQWebCrypto._pbkdf2(password, salt, this.iterations, this.keyLength, this.hash);
-            const cryptoKey = await window.crypto.subtle.importKey('raw', derivedKey, { name: this.algorithm }, false, ['decrypt']);
-            
-            const metadataSlice = file.slice(contentStart, contentStart + 4);
-            const metadataBytes = await new Response(metadataSlice).arrayBuffer();
-            const metadataView = new DataView(metadataBytes);
-            const chunkCount = metadataView.getUint32(0, true);
-
-            const lengthsSlice = file.slice(contentStart + 4, contentStart + 4 + (chunkCount * 4));
-            const lengthsBytes = await new Response(lengthsSlice).arrayBuffer();
-            const lengthsView = new DataView(lengthsBytes);
-            const chunkLengths = [];
-            for (let i = 0; i < chunkCount; i++) {
-                chunkLengths.push(lengthsView.getUint32(i * 4, true));
-            }
-
-            const decryptedChunks = [];
-            let currentPosition = contentStart + 4 + (chunkCount * 4);
-            
-            for (const chunkLength of chunkLengths) {
-                const chunkSlice = file.slice(currentPosition, currentPosition + chunkLength);
-                const chunkBytes = await new Response(chunkSlice).arrayBuffer();
-                const chunkData = new Uint8Array(chunkBytes);
-                
-                try {
-                    const decryptedChunk = await this.decryptChunk(chunkData, cryptoKey);
-                    decryptedChunks.push(decryptedChunk);
-                    currentPosition += chunkLength;
-                } catch (error) {
-                    throw new Error(`Authentication failed at chunk: ${error.message}`);
-                }
-            }
-            
-            // Return a Blob instead of Uint8Array to avoid 2GB limit
-            return new Blob(decryptedChunks, { type: 'application/octet-stream' });
-        },
-
-        decryptChunk: async function (chunk, cryptoKey) {
-            const iv = chunk.slice(0, this.ivLength);
-            const encryptedData = chunk.slice(this.ivLength);
-            
-            const decrypted = await window.crypto.subtle.decrypt(
-                { name: this.algorithm, iv: iv },
-                cryptoKey,
-                encryptedData
-            );
-            
-            return new Uint8Array(decrypted);
         }
     },
     // Counter mode encrpytion.
@@ -630,12 +519,21 @@ export const XQWebCrypto = {
             const chunkSize = 1024 * 1024;
             const reader = file.stream().getReader();
             const encryptedChunks = [];
-            encryptedChunks.push(header);
+            const batchedBlobs = [];
+            const batchSize = 1000;
             
-            // Derive the key once using PBKDF2
+            const bodySalt = window.crypto.getRandomValues(new Uint8Array(this.saltLength));
+            const saltedHeader = new Uint8Array(header.length + 8 + this.saltLength);
+            saltedHeader.set(header, 0);
+            saltedHeader.set(new TextEncoder().encode("Salted__"), header.length);
+            saltedHeader.set(bodySalt, header.length + 8);
+            
+            // Add header to the first batch
+            batchedBlobs.push(new Blob([saltedHeader], { type: 'application/octet-stream' }));
+            
+            // Derive the key once using PBKDF2 with the body's salt
             if (password[0] === '.') password = password.slice(2);
-            const salt = header.slice(header.length - this.saltLength, header.length);
-            const derivedKey = await XQWebCrypto._pbkdf2(password, salt, this.iterations, this.keyLength, this.hash);
+            const derivedKey = await XQWebCrypto._pbkdf2(password, bodySalt, this.iterations, this.keyLength, this.hash);
             const cryptoKey = await window.crypto.subtle.importKey('raw', derivedKey, { name: this.algorithm }, false, ['encrypt']);
 
             while (true) {
@@ -644,10 +542,23 @@ export const XQWebCrypto = {
 
                 const encryptedChunk = await this.encryptChunk(value, cryptoKey);
                 encryptedChunks.push(encryptedChunk);
+                
+                // Batch: create intermediate Blob when we hit batchSize
+                if (encryptedChunks.length >= batchSize) {
+                    const intermediateBlob = new Blob(encryptedChunks, { type: 'application/octet-stream' });
+                    batchedBlobs.push(intermediateBlob);
+                    encryptedChunks.length = 0;
+                }
+            }
+            
+            // Handle remaining chunks
+            if (encryptedChunks.length > 0) {
+                const intermediateBlob = new Blob(encryptedChunks, { type: 'application/octet-stream' });
+                batchedBlobs.push(intermediateBlob);
             }
 
-            // Return a Blob instead of Uint8Array to avoid 2GB limit
-            return new Blob(encryptedChunks, { type: 'application/octet-stream' });
+            // Final Blob from all intermediate Blobs
+            return new Blob(batchedBlobs, { type: 'application/octet-stream' });
         },
 
         encryptChunk: async function (chunk, cryptoKey) {
@@ -674,20 +585,28 @@ export const XQWebCrypto = {
             const fileSize = file.size;
             const contentStart = header.length;
             
-            // Derive the key once using PBKDF2
             if (password[0] === '.') password = password.slice(2);
-            const headerSlice = file.slice(0, contentStart);
-            const headerBytes = await new Response(headerSlice).arrayBuffer();
-            const headerData = new Uint8Array(headerBytes);
-            const salt = headerData.slice(headerData.length - this.saltLength, headerData.length);
+            const saltHeaderSlice = file.slice(contentStart, contentStart + 8 + this.saltLength);
+            const saltHeaderBytes = await new Response(saltHeaderSlice).arrayBuffer();
+            const saltHeaderData = new Uint8Array(saltHeaderBytes);
             
-            const derivedKey = await XQWebCrypto._pbkdf2(password, salt, this.iterations, this.keyLength, this.hash);
+            // Verify "Salted__" prefix
+            const prefix = new TextDecoder().decode(saltHeaderData.slice(0, 8));
+            if (prefix !== "Salted__") {
+                throw new Error("Invalid file format: missing salt header");
+            }
+            
+            // Extract the body's salt
+            const bodySalt = saltHeaderData.slice(8, 8 + this.saltLength);
+            
+            const derivedKey = await XQWebCrypto._pbkdf2(password, bodySalt, this.iterations, this.keyLength, this.hash);
             const cryptoKey = await window.crypto.subtle.importKey('raw', derivedKey, { name: this.algorithm }, false, ['decrypt']);
             
             const decryptedChunks = [];
-            const actualContentStart = contentStart;
+            const batchedBlobs = [];
+            const batchSize = 1000;
+            const actualContentStart = contentStart + 8 + this.saltLength;
             const actualContentEnd = fileSize;
-            
             let currentPosition = actualContentStart;
 
             while (currentPosition < actualContentEnd) {
@@ -705,13 +624,26 @@ export const XQWebCrypto = {
                     const decryptedChunk = await this.decryptChunk(chunkData, cryptoKey);
                     decryptedChunks.push(decryptedChunk);
                     currentPosition += chunkData.length;
+                    
+                    // Batch: create intermediate Blob when we hit batchSize
+                    if (decryptedChunks.length >= batchSize) {
+                        const intermediateBlob = new Blob(decryptedChunks, { type: 'application/octet-stream' });
+                        batchedBlobs.push(intermediateBlob);
+                        decryptedChunks.length = 0;
+                    }
                 } catch (error) {
                     throw new Error(`Decryption failed at position ${currentPosition}: ${error.message}`);
                 }
             }
 
-            // Return a Blob instead of Uint8Array to avoid 2GB limit
-            return new Blob(decryptedChunks, { type: 'application/octet-stream' });
+            // Handle remaining chunks
+            if (decryptedChunks.length > 0) {
+                const intermediateBlob = new Blob(decryptedChunks, { type: 'application/octet-stream' });
+                batchedBlobs.push(intermediateBlob);
+            }
+
+            // Final Blob from all intermediate Blobs
+            return new Blob(batchedBlobs, { type: 'application/octet-stream' });
         },
 
         decryptChunk: async function (chunk, cryptoKey) {
@@ -1152,24 +1084,39 @@ export const XQWebCrypto = {
         },
         
         encryptFileStreaming: async function (file, password, header) {
-            const chunkSize = 1024 * 1024;
             const reader = file.stream().getReader();
             const encryptedChunks = [];
+            const batchedBlobs = [];
+            const batchSize = 1000;
             let keyOffset = 0;
-            encryptedChunks.push(header);
+
+            // Add header to the first batch
+            batchedBlobs.push(new Blob([header], { type: 'application/octet-stream' }));
 
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) break;
-
                 const encryptedChunk = await this.encryptChunk(value, password, keyOffset);
                 encryptedChunks.push(encryptedChunk);
                 
                 keyOffset = (keyOffset + value.length) % (password.length - 2); // -2 for prefix
+                
+                // Batch: create intermediate Blob when we hit batchSize
+                if (encryptedChunks.length >= batchSize) {
+                    const intermediateBlob = new Blob(encryptedChunks, { type: 'application/octet-stream' });
+                    batchedBlobs.push(intermediateBlob);
+                    encryptedChunks.length = 0;
+                }
+            }
+            
+            // Handle remaining chunks
+            if (encryptedChunks.length > 0) {
+                const intermediateBlob = new Blob(encryptedChunks, { type: 'application/octet-stream' });
+                batchedBlobs.push(intermediateBlob);
             }
 
-            // Return a Blob instead of Uint8Array to avoid 2GB limit
-            return new Blob(encryptedChunks, { type: 'application/octet-stream' });
+            // Final Blob from all intermediate Blobs
+            return new Blob(batchedBlobs, { type: 'application/octet-stream' });
         },
 
         encryptChunk: async function (chunk, password, keyOffset) {
@@ -1195,6 +1142,8 @@ export const XQWebCrypto = {
             const contentSize = fileSize - contentStart;
             
             const decryptedChunks = [];
+            const batchedBlobs = [];
+            const batchSize = 1000; 
             let keyOffset = 0;
             let processedBytes = 0;
 
@@ -1208,12 +1157,23 @@ export const XQWebCrypto = {
                 
                 keyOffset = (keyOffset + chunkBytes.byteLength) % (password.length - 2);
                 processedBytes += chunkBytes.byteLength;
+                
+                // Batch: create intermediate Blob when we hit batchSize
+                if (decryptedChunks.length >= batchSize) {
+                    const intermediateBlob = new Blob(decryptedChunks, { type: 'application/octet-stream' });
+                    batchedBlobs.push(intermediateBlob);
+                    decryptedChunks.length = 0;
+                }
             }
 
-            const totalLength = decryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
-            const finalResult = new Uint8Array(totalLength);
-            // Return a Blob instead of Uint8Array to avoid 2GB limit
-            return new Blob(decryptedChunks, { type: 'application/octet-stream' });
+            // Handle remaining chunks
+            if (decryptedChunks.length > 0) {
+                const intermediateBlob = new Blob(decryptedChunks, { type: 'application/octet-stream' });
+                batchedBlobs.push(intermediateBlob);
+            }
+
+            // Final Blob from all intermediate Blobs
+            return new Blob(batchedBlobs, { type: 'application/octet-stream' });
         },
 
         decryptChunk: async function (chunk, password, keyOffset) {

--- a/src/com/xqmsg/web-crypto/webcrypto.js
+++ b/src/com/xqmsg/web-crypto/webcrypto.js
@@ -348,6 +348,11 @@ export const XQWebCrypto = {
     },
 
     _decryptFile: async function (algo, byteContent, onFetchPassword, onComplete) {
+
+        if (byteContent instanceof File) {
+            return XQWebCrypto._decryptFileStreaming(algo, byteContent, onFetchPassword, onComplete);
+        }
+
         var data = new Uint8Array(byteContent);
         return XQWebCrypto.getFileHeader(data).then(function (header) {
             var buf = data.slice(header.length);
@@ -369,6 +374,54 @@ export const XQWebCrypto = {
         }).catch(function (err) {
             onComplete(false, err.message ?? err);
         });
+    },
+
+    _decryptFileStreaming: async function (algo, file, onFetchPassword, onComplete) {
+        try {
+            const headerSlice = file.slice(0, 1024);
+            const headerBytes = await new Response(headerSlice).arrayBuffer();
+            const headerData = new Uint8Array(headerBytes);
+            
+            const header = await XQWebCrypto.getFileHeader(headerData);
+            
+            onFetchPassword(header.token, async function (password) {
+                try {
+                    if (header.filename) {
+                        try {
+                            header.filename = await algo.decrypt(header.filename, password, true);
+                            header.filename = new TextDecoder("utf-8").decode(header.filename);
+                        } catch (err) {
+                            onComplete(false, err.message ?? err);
+                            return;
+                        }
+                    }
+
+                    // Only use streaming for OTP algorithm for now
+                    if (algo.algorithm !== 'OTP') {
+
+                        const fileArrayBuffer = await new Response(file).arrayBuffer();
+                        const data = new Uint8Array(fileArrayBuffer);
+                        const buf = data.slice(header.length);
+                        
+                        algo.decrypt(buf, password, true).then(function (decrypted) {
+                            onComplete(true, header.filename, decrypted);
+                        }).catch(function (err) {
+                            onComplete(false, err.message ?? err);
+                        });
+                        return;
+                    }
+
+                    const result = await XQWebCrypto.otp.decryptFileStreaming(file, password, header);
+                    onComplete(true, header.filename, result);
+
+                } catch (err) {
+                    onComplete(false, err.message ?? err);
+                }
+            });
+            
+        } catch (err) {
+            onComplete(false, err.message ?? err);
+        }
     },
 
     decryptFile: async function (byteContent, onFetchPassword, onComplete) {
@@ -867,6 +920,7 @@ export const XQWebCrypto = {
             return XQWebCrypto._encryptFile(this, filename, byteContent, token,
                 password, onComplete);
         },
+
         decryptFile: async function (byteContent, onFetchPassword, onComplete) {
             return XQWebCrypto._decryptFile(this, byteContent, onFetchPassword, onComplete)
                 .catch(function (err) {
@@ -917,6 +971,57 @@ export const XQWebCrypto = {
             }
 
             return encrypted;
+        },
+
+        decryptFileStreaming: async function (file, password, header) {
+            const chunkSize = 1024 * 1024;
+            const fileSize = file.size;
+            const contentStart = header.length;
+            const contentSize = fileSize - contentStart;
+            
+            const decryptedChunks = [];
+            let keyOffset = 0;
+            let processedBytes = 0;
+
+            while (processedBytes < contentSize) {
+                const chunkStart = contentStart + processedBytes;
+                const chunkEnd = Math.min(chunkStart + chunkSize, fileSize);
+                const chunkSlice = file.slice(chunkStart, chunkEnd);
+                const chunkBytes = await new Response(chunkSlice).arrayBuffer();
+                const decryptedChunk = await this.decryptChunk(new Uint8Array(chunkBytes), password, keyOffset);
+                decryptedChunks.push(decryptedChunk);
+                
+                keyOffset = (keyOffset + chunkBytes.byteLength) % (password.length - 2);
+                processedBytes += chunkBytes.byteLength;
+            }
+
+            const totalLength = decryptedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+            const finalResult = new Uint8Array(totalLength);
+            let offset = 0;
+            
+            for (const chunk of decryptedChunks) {
+                finalResult.set(chunk, offset);
+                offset += chunk.length;
+            }
+
+            return finalResult;
+        },
+
+        decryptChunk: async function (chunk, password, keyOffset) {
+
+            if (password[0] === '.') password = password.slice(2);
+            
+            var encoder = new TextEncoder("utf8");
+            var keyBytes = encoder.encode(password);
+            var payloadBytes = new Uint8Array(chunk);
+            var decrypted = new Uint8Array(payloadBytes.length);
+
+            for (var idx = 0; idx < payloadBytes.length; idx++) {
+                var keyIdx = (keyOffset + idx) % keyBytes.length;
+                decrypted[idx] = payloadBytes[idx] ^ keyBytes[keyIdx];
+            }
+
+            return decrypted;
         }
     },
     auto: {


### PR DESCRIPTION
This PR implements chunk-based streaming for file encryption and decryption in the JS SDK to handle large files without causing browser memory crashes.

**Problem**
The previous implementation used `new Response(file).arrayBuffer()` which loaded entire files into memory, causing:

- Browser crashes when encrypting/decrypting large files (>2GB)
- Memory exhaustion on files approaching 5GB
- Failed File/Blob constructors due to 2GB ArrayBuffer/ArrayBufferView limits in browsers

**Solution**
Implemented streaming encryption/decryption using `File.stream().getReader()` with 1MB chunks for OTP, AES-GCM, and AES-CTR algorithms. All file operations now use streaming regardless of file size for consistent memory usage.

Encryption:
<img width="574" height="308" alt="image" src="https://github.com/user-attachments/assets/31621c22-9eb6-4b3b-8a2a-ea1dc024233f" />

Decryption:
<img width="627" height="157" alt="image" src="https://github.com/user-attachments/assets/137aa1cd-7381-4e76-989f-eaaabbf57066" />

**Additional notes:**
- Exchange Step Update: Added teamId as a parameter in the exchange step, didn't send it into the code validator since it was being sent to the endpoint too. `?pin=123&b=111`